### PR TITLE
Add missing methods for EventCategory and EventWiki relationship

### DIFF
--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -357,6 +357,24 @@ class Event
 
     // @see EventStatTrait
 
+    /**************
+     * CATEGORIES *
+     **************/
+
+    /**
+     * Are there any categories set on EventWikis associated with this Event?
+     * @return bool
+     */
+    public function hasCategories()
+    {
+        foreach ($this->wikis as $wiki) {
+            if (count($wiki->getCategories()) > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /****************
      * PARTICIPANTS *
      ****************/

--- a/src/AppBundle/Model/EventCategory.php
+++ b/src/AppBundle/Model/EventCategory.php
@@ -60,11 +60,12 @@ class EventCategory
     public function __construct(EventWiki $wiki, $categoryId)
     {
         $this->wiki = $wiki;
+        $this->wiki->addCategory($this);
         $this->categoryId = $categoryId;
     }
 
     /**
-     * Get the Event this EventWikiStat applies to.
+     * Get the Event this EventWiki applies to.
      * @return Event
      */
     public function getEvent()
@@ -73,11 +74,20 @@ class EventCategory
     }
 
     /**
-     * Get the EventWiki this EventWikiStat applies to.
+     * Get the EventWiki this EventWiki applies to.
      * @return EventWiki
      */
     public function getWiki()
     {
         return $this->wiki;
+    }
+
+    /**
+     * ID of the category in the MediaWiki database.
+     * @return int
+     */
+    public function getCategoryId()
+    {
+        return $this->categoryId;
     }
 }

--- a/src/AppBundle/Model/EventWiki.php
+++ b/src/AppBundle/Model/EventWiki.php
@@ -73,6 +73,13 @@ class EventWiki
     protected $stats;
 
     /**
+     * One EventWiki has many EventCategory's.
+     * @ORM\OneToMany(targetEntity="EventCategory", mappedBy="wiki", orphanRemoval=true, cascade={"persist"})
+     * @var ArrayCollection|EventCategory[] Category's for this EventWiki.
+     */
+    protected $categories;
+
+    /**
      * EventWiki constructor.
      * @param Event $event Event that this EventWiki belongs to.
      * @param string $domain Domain name of the wiki, without the .org.
@@ -83,6 +90,7 @@ class EventWiki
         $this->event->addWiki($this);
         $this->domain = $domain;
         $this->stats = new ArrayCollection();
+        $this->categories = new ArrayCollection();
     }
 
     /**
@@ -114,6 +122,63 @@ class EventWiki
     public static function getValidPattern()
     {
         return self::VALID_WIKI_PATTERN;
+    }
+
+    /**************
+     * CATEGORIES *
+     **************/
+
+    /**
+     * Get categories configured for this wiki.
+     * @return EventCategory[]|ArrayCollection
+     */
+    public function getCategories()
+    {
+        return $this->categories;
+    }
+
+    /**
+     * Get the IDs of all the categories for this EventWiki.
+     * This correlates to the cat_id in the category table on the WMF replicas.
+     * @return array
+     */
+    public function getCategoryIds()
+    {
+        return array_map(function (EventCategory $category) {
+            return $category->getCategoryId();
+        }, $this->categories->toArray());
+    }
+
+    /**
+     * Add an EventCategory to this EventWiki.
+     * @param EventCategory $category
+     */
+    public function addCategory(EventCategory $category)
+    {
+        if ($this->categories->contains($category)) {
+            return;
+        }
+        $this->categories->add($category);
+    }
+
+    /**
+     * Remove an EventCategory from this EventWiki.
+     * @param EventCategory $category
+     */
+    public function removeCategory(EventCategory $category)
+    {
+        if (!$this->categories->contains($category)) {
+            return;
+        }
+        $this->categories->removeElement($category);
+    }
+
+    /**
+     * Clear all associated statistics.
+     */
+    public function clearCategories()
+    {
+        $this->categories->clear();
     }
 
     /***************

--- a/tests/AppBundle/Command/ProcessEventCommandTest.php
+++ b/tests/AppBundle/Command/ProcessEventCommandTest.php
@@ -5,7 +5,6 @@
 
 namespace Tests\AppBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
@@ -15,11 +14,12 @@ use AppBundle\DataFixtures\ORM\LoadFixtures;
 use AppBundle\Command\ProcessEventCommand;
 use AppBundle\Model\Job;
 use AppBundle\Model\Event;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the ProcessEventCommand.
  */
-class ProcessEventCommandTest extends KernelTestCase
+class ProcessEventCommandTest extends GrantMetricsTestCase
 {
     /**
      * @var ORMExecutor
@@ -49,6 +49,8 @@ class ProcessEventCommandTest extends KernelTestCase
 
     public function setUp()
     {
+        parent::setUp();
+
         self::bootKernel();
 
         $container = self::$kernel->getContainer();

--- a/tests/AppBundle/Command/SpawnJobsCommandTest.php
+++ b/tests/AppBundle/Command/SpawnJobsCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
@@ -13,11 +12,12 @@ use AppBundle\Command\SpawnJobsCommand;
 use AppBundle\Model\Event;
 use AppBundle\Model\Job;
 use DateTime;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the SpawnJobsCommand.
  */
-class SpawnJobsCommandTest extends KernelTestCase
+class SpawnJobsCommandTest extends GrantMetricsTestCase
 {
     /**
      * @var ORMExecutor
@@ -47,6 +47,8 @@ class SpawnJobsCommandTest extends KernelTestCase
 
     public function setUp()
     {
+        parent::setUp();
+
         self::bootKernel();
 
         /** @var \Doctrine\ORM\EntityManager $entityManager */

--- a/tests/AppBundle/Controller/DatabaseAwareWebTestCase.php
+++ b/tests/AppBundle/Controller/DatabaseAwareWebTestCase.php
@@ -9,15 +9,15 @@ use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Client;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * This ensures fixtures are loaded with every functional test.
  */
-abstract class DatabaseAwareWebTestCase extends WebTestCase
+abstract class DatabaseAwareWebTestCase extends GrantMetricsTestCase
 {
     /**
      * @var ORMExecutor

--- a/tests/AppBundle/GrantMetricsTestCase.php
+++ b/tests/AppBundle/GrantMetricsTestCase.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file contains only the GrantMetricsTestCase class.
+ */
+
+namespace Tests\AppBundle;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Class GrantMetricsTestCase
+ * @package Tests\AppBundle
+ */
+class GrantMetricsTestCase extends WebTestCase
+{
+    public function setUp()
+    {
+        date_default_timezone_set('UTC');
+    }
+}

--- a/tests/AppBundle/Model/EventCategoryTest.php
+++ b/tests/AppBundle/Model/EventCategoryTest.php
@@ -10,10 +10,13 @@ use AppBundle\Model\EventCategory;
 use AppBundle\Model\EventWiki;
 use AppBundle\Model\Organizer;
 use AppBundle\Model\Program;
+use Tests\AppBundle\GrantMetricsTestCase;
 
-use PHPUnit_Framework_TestCase;
-
-class EventCategoryTest extends PHPUnit_Framework_TestCase
+/**
+ * Class EventCategoryTest
+ * @package Tests\AppBundle\Model
+ */
+class EventCategoryTest extends GrantMetricsTestCase
 {
     /**
      * Tests constructor and basic getters.
@@ -31,7 +34,11 @@ class EventCategoryTest extends PHPUnit_Framework_TestCase
         );
         $wiki = new EventWiki($event, 'test.wikipedia');
 
+        static::assertFalse($event->hasCategories());
+
         $eventCategory = new EventCategory($wiki, 500);
+
+        static::assertTrue($event->hasCategories());
 
         // Getters.
         static::assertEquals($event, $eventCategory->getEvent());

--- a/tests/AppBundle/Model/EventStatTest.php
+++ b/tests/AppBundle/Model/EventStatTest.php
@@ -5,17 +5,17 @@
 
 namespace Tests\AppBundle\Model;
 
-use PHPUnit_Framework_TestCase;
 use AppBundle\Model\Event;
 use AppBundle\Model\EventStat;
 use AppBundle\Model\Organizer;
 use AppBundle\Model\Program;
 use InvalidArgumentException;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the EventStat class.
  */
-class EventStatTest extends PHPUnit_Framework_TestCase
+class EventStatTest extends GrantMetricsTestCase
 {
     /**
      * Tests constructor and basic getters.

--- a/tests/AppBundle/Model/EventTest.php
+++ b/tests/AppBundle/Model/EventTest.php
@@ -5,7 +5,6 @@
 
 namespace Tests\AppBundle\Model;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use AppBundle\Model\Event;
 use AppBundle\Model\EventStat;
 use AppBundle\Model\EventWiki;
@@ -14,18 +13,20 @@ use AppBundle\Model\Organizer;
 use AppBundle\Model\Program;
 use AppBundle\Model\Participant;
 use DateTime;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the Event class.
  */
-class EventTest extends KernelTestCase
+class EventTest extends GrantMetricsTestCase
 {
     /** @var Program The Program that the Event is part of. */
     protected $program;
 
     public function setUp()
     {
-        date_default_timezone_set('UTC');
+        parent::setUp();
+
         $organizer = new Organizer(50);
         $this->program = new Program($organizer);
     }

--- a/tests/AppBundle/Model/EventWikiStatTest.php
+++ b/tests/AppBundle/Model/EventWikiStatTest.php
@@ -5,18 +5,18 @@
 
 namespace Tests\AppBundle\Model;
 
-use PHPUnit_Framework_TestCase;
 use AppBundle\Model\Event;
 use AppBundle\Model\EventWiki;
 use AppBundle\Model\EventWikiStat;
 use AppBundle\Model\Organizer;
 use AppBundle\Model\Program;
 use InvalidArgumentException;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the EventWikiStat class.
  */
-class EventWikiStatTest extends PHPUnit_Framework_TestCase
+class EventWikiStatTest extends GrantMetricsTestCase
 {
     /**
      * Tests constructor and basic getters.

--- a/tests/AppBundle/Model/EventWikiTest.php
+++ b/tests/AppBundle/Model/EventWikiTest.php
@@ -5,25 +5,26 @@
 
 namespace Tests\AppBundle\Model;
 
+use AppBundle\Model\EventCategory;
 use Doctrine\Common\Collections\ArrayCollection;
-use PHPUnit_Framework_TestCase;
 use AppBundle\Model\EventWiki;
 use AppBundle\Model\Program;
 use AppBundle\Model\Event;
 use AppBundle\Model\EventWikiStat;
 use AppBundle\Model\Organizer;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the EventWiki class.
  */
-class EventWikiTest extends PHPUnit_Framework_TestCase
+class EventWikiTest extends GrantMetricsTestCase
 {
     /** @var Event The Event that the EventWiki is part of. */
     protected $event;
 
     public function setUp()
     {
-        date_default_timezone_set('UTC');
+        parent::setUp();
 
         $organizer = new Organizer(50);
         $program = new Program($organizer);
@@ -88,6 +89,38 @@ class EventWikiTest extends PHPUnit_Framework_TestCase
         static::assertEquals(1, $wiki->getStatistics()->count());
         $wiki->clearStatistics();
         static::assertEquals(0, $wiki->getStatistics()->count());
+    }
+
+    /**
+     * Test adding and removing categories.
+     */
+    public function testAddRemoveCategories()
+    {
+        $wiki = new EventWiki($this->event, 'test.wikipedia');
+
+        static::assertEquals(0, count($wiki->getCategories()));
+
+        // Add an EventCategory.
+        $cat = new EventCategory($wiki, 500);
+
+        static::assertEquals($cat, $wiki->getCategories()[0]);
+
+        // Try adding the same one, which shouldn't duplicate.
+        $wiki->addCategory($cat);
+        static::assertEquals(1, count($wiki->getCategories()));
+
+        // Removing the statistic.
+        $wiki->removeCategory($cat);
+        static::assertEquals(0, count($wiki->getCategories()));
+
+        // Double-remove shouldn't error out.
+        $wiki->removeCategory($cat);
+
+        // Clearing statistics.
+        $wiki->addCategory($cat);
+        static::assertEquals(1, $wiki->getCategories()->count());
+        $wiki->clearCategories();
+        static::assertEquals(0, $wiki->getCategories()->count());
     }
 
     /**

--- a/tests/AppBundle/Model/JobTest.php
+++ b/tests/AppBundle/Model/JobTest.php
@@ -5,16 +5,16 @@
 
 namespace Tests\AppBundle\Model;
 
-use PHPUnit_Framework_TestCase;
 use AppBundle\Model\Job;
 use AppBundle\Model\Event;
 use AppBundle\Model\Program;
 use AppBundle\Model\Organizer;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the Job class.
  */
-class JobTest extends PHPUnit_Framework_TestCase
+class JobTest extends GrantMetricsTestCase
 {
     /**
      * Tests constructor and basic getters/setters.

--- a/tests/AppBundle/Model/OrganizerTest.php
+++ b/tests/AppBundle/Model/OrganizerTest.php
@@ -5,14 +5,14 @@
 
 namespace Tests\AppBundle\Model;
 
-use PHPUnit_Framework_TestCase;
 use AppBundle\Model\Organizer;
 use AppBundle\Model\Program;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the Organizer class.
  */
-class OrganizerTest extends PHPUnit_Framework_TestCase
+class OrganizerTest extends GrantMetricsTestCase
 {
     /**
      * Tests constructor and basic getters.

--- a/tests/AppBundle/Model/ParticipantTest.php
+++ b/tests/AppBundle/Model/ParticipantTest.php
@@ -5,16 +5,16 @@
 
 namespace Tests\AppBundle\Model;
 
-use PHPUnit_Framework_TestCase;
 use AppBundle\Model\Participant;
 use AppBundle\Model\Event;
 use AppBundle\Model\Organizer;
 use AppBundle\Model\Program;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the Participant class.
  */
-class ParticipantTest extends PHPUnit_Framework_TestCase
+class ParticipantTest extends GrantMetricsTestCase
 {
     /**
      * Tests constructor and basic getters.

--- a/tests/AppBundle/Model/ProgramTest.php
+++ b/tests/AppBundle/Model/ProgramTest.php
@@ -9,12 +9,12 @@ use AppBundle\Model\Program;
 use AppBundle\Model\Event;
 use AppBundle\Model\EventStat;
 use AppBundle\Model\Organizer;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the Program class.
  */
-class ProgramTest extends KernelTestCase
+class ProgramTest extends GrantMetricsTestCase
 {
     /** @var Organizer The Organizer of the Program. */
     protected $organizer;
@@ -27,6 +27,8 @@ class ProgramTest extends KernelTestCase
      */
     public function setUp()
     {
+        parent::setUp();
+
         $this->organizer = new Organizer(50);
         $this->program = new Program($this->organizer);
     }

--- a/tests/AppBundle/Twig/AppExtensionTest.php
+++ b/tests/AppBundle/Twig/AppExtensionTest.php
@@ -5,23 +5,21 @@
 
 namespace AppBundle\Twig;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
-use AppBundle\Twig\AppExtension;
-use AppBundle\Twig\Extension;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the AppExtension class.
  * Some code courtesy of the XTools team, released under GPL-3.0: https://github.com/x-tools/xtools
  */
-class AppExtensionTest extends WebTestCase
+class AppExtensionTest extends GrantMetricsTestCase
 {
     /** @var Container The Symfony container. */
     protected $container;
 
-    /** @var AppBundle\Twig\AppExtension Instance of class */
+    /** @var \AppBundle\Twig\AppExtension Instance of class */
     protected $appExtension;
 
     /**
@@ -29,8 +27,10 @@ class AppExtensionTest extends WebTestCase
      */
     public function setUp()
     {
-        $this->client = static::createClient();
-        $this->container = $this->client->getContainer();
+        parent::setUp();
+
+        $client = static::createClient();
+        $this->container = $client->getContainer();
         $stack = new RequestStack();
         $session = new Session();
         $this->appExtension = new AppExtension($this->container, $stack, $session);

--- a/tests/AppBundle/Twig/FormatExtensionTest.php
+++ b/tests/AppBundle/Twig/FormatExtensionTest.php
@@ -5,24 +5,22 @@
 
 namespace AppBundle\Twig;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
-use AppBundle\Twig\AppExtension;
-use AppBundle\Twig\Extension;
 use DateTime;
+use Tests\AppBundle\GrantMetricsTestCase;
 
 /**
  * Tests for the FormatExtension class.
  * Some code courtesy of the XTools team, released under GPL-3.0: https://github.com/x-tools/xtools
  */
-class FormatExtensionTest extends WebTestCase
+class FormatExtensionTest extends GrantMetricsTestCase
 {
     /** @var Container The Symfony container. */
     protected $container;
 
-    /** @var AppBundle\Twig\FormatExtension Instance of class */
+    /** @var \AppBundle\Twig\FormatExtension Instance of class */
     protected $formatExtension;
 
     /**
@@ -30,8 +28,10 @@ class FormatExtensionTest extends WebTestCase
      */
     public function setUp()
     {
-        $this->client = static::createClient();
-        $this->container = $this->client->getContainer();
+        parent::setUp();
+
+        $client = static::createClient();
+        $this->container = $client->getContainer();
         $stack = new RequestStack();
         $session = new Session();
         $this->formatExtension = new FormatExtension($this->container, $stack, $session);
@@ -42,15 +42,15 @@ class FormatExtensionTest extends WebTestCase
      */
     public function testDiffFormat()
     {
-        $this->assertEquals(
+        static::assertEquals(
             "<span class='diff-pos'>3,000</span>",
             $this->formatExtension->diffFormat(3000)
         );
-        $this->assertEquals(
+        static::assertEquals(
             "<span class='diff-neg'>-20,000</span>",
             $this->formatExtension->diffFormat(-20000)
         );
-        $this->assertEquals(
+        static::assertEquals(
             "<span class='diff-zero'>0</span>",
             $this->formatExtension->diffFormat(0)
         );
@@ -61,10 +61,10 @@ class FormatExtensionTest extends WebTestCase
      */
     public function testPercentFormat()
     {
-        $this->assertEquals('45%', $this->formatExtension->percentFormat(45));
-        $this->assertEquals('30%', $this->formatExtension->percentFormat(30, null, 3));
-        $this->assertEquals('33.33%', $this->formatExtension->percentFormat(2, 6, 2));
-        $this->assertEquals('25%', $this->formatExtension->percentFormat(2, 8));
+        static::assertEquals('45%', $this->formatExtension->percentFormat(45));
+        static::assertEquals('30%', $this->formatExtension->percentFormat(30, null, 3));
+        static::assertEquals('33.33%', $this->formatExtension->percentFormat(2, 6, 2));
+        static::assertEquals('25%', $this->formatExtension->percentFormat(2, 8));
     }
 
     /**
@@ -72,23 +72,23 @@ class FormatExtensionTest extends WebTestCase
      */
     public function testFormatDuration()
     {
-        $this->assertEquals(
+        static::assertEquals(
             [30, 'num-seconds'],
             $this->formatExtension->formatDuration(30, false)
         );
-        $this->assertEquals(
+        static::assertEquals(
             [1, 'num-minutes'],
             $this->formatExtension->formatDuration(70, false)
         );
-        $this->assertEquals(
+        static::assertEquals(
             [50, 'num-minutes'],
             $this->formatExtension->formatDuration(3000, false)
         );
-        $this->assertEquals(
+        static::assertEquals(
             [2, 'num-hours'],
             $this->formatExtension->formatDuration(7500, false)
         );
-        $this->assertEquals(
+        static::assertEquals(
             [10, 'num-days'],
             $this->formatExtension->formatDuration(864000, false)
         );
@@ -99,9 +99,9 @@ class FormatExtensionTest extends WebTestCase
      */
     public function testNumberFormat()
     {
-        $this->assertEquals('1,234', $this->formatExtension->numberFormat(1234));
-        $this->assertEquals('1,234.32', $this->formatExtension->numberFormat(1234.316, 2));
-        $this->assertEquals('50', $this->formatExtension->numberFormat(50.0000, 4));
+        static::assertEquals('1,234', $this->formatExtension->numberFormat(1234));
+        static::assertEquals('1,234.32', $this->formatExtension->numberFormat(1234.316, 2));
+        static::assertEquals('50', $this->formatExtension->numberFormat(50.0000, 4));
     }
 
     /**
@@ -110,21 +110,21 @@ class FormatExtensionTest extends WebTestCase
     public function testDateFormat()
     {
         // Localized.
-        $this->assertEquals(
+        static::assertEquals(
             '2/1/17, 11:45 PM',
             $this->formatExtension->dateFormat(new DateTime('2017-02-01 23:45:34'))
         );
-        $this->assertEquals(
+        static::assertEquals(
             '8/12/15, 11:45 AM',
             $this->formatExtension->dateFormat('2015-08-12 11:45:50')
         );
 
         // ISO 8601.
-        $this->assertEquals(
+        static::assertEquals(
             '2017-02-01 23:45',
             $this->formatExtension->dateFormatStd(new DateTime('2017-02-01 23:45:34'))
         );
-        $this->assertEquals(
+        static::assertEquals(
             '2015-08-12 11:45',
             $this->formatExtension->dateFormatStd('2015-08-12 11:45:50')
         );
@@ -135,8 +135,8 @@ class FormatExtensionTest extends WebTestCase
      */
     public function testCapitalizeFirst()
     {
-        $this->assertEquals('Foo', $this->formatExtension->ucfirst('foo'));
-        $this->assertEquals('Bar', $this->formatExtension->ucfirst('Bar'));
+        static::assertEquals('Foo', $this->formatExtension->ucfirst('foo'));
+        static::assertEquals('Bar', $this->formatExtension->ucfirst('Bar'));
     }
 
     /**
@@ -145,14 +145,14 @@ class FormatExtensionTest extends WebTestCase
     public function testWikify()
     {
         $wikitext = '<script>alert("XSS baby")</script> [[test page]]';
-        $this->assertEquals(
+        static::assertEquals(
             "&lt;script&gt;alert(\"XSS baby\")&lt;/script&gt; " .
                 "<a target='_blank' href='https://test.example.org/wiki/Test_page'>test page</a>",
             $this->formatExtension->wikify($wikitext, 'test.example')
         );
 
         $wikitext = '/* My section */ Editing a specific &quot;section&quot;';
-        $this->assertEquals(
+        static::assertEquals(
             "<a target='_blank' href='https://test.example.org/wiki/My_fun_page#My_section'>".
                 "&rarr;</a><em class='text-muted'>My section:</em> Editing a specific \"section\"",
             $this->formatExtension->wikify($wikitext, 'test.example', 'my fun page')


### PR DESCRIPTION
Make all tests extend GrantMetricsTestCase, which sets the default timezone.