### PR TITLE
Move new-participants textarea above list of existing participants

### DIFF
--- a/app/Resources/assets/css/events.scss
+++ b/app/Resources/assets/css/events.scss
@@ -16,10 +16,6 @@
         margin-bottom: 0;
     }
 
-    .event-add-participants {
-        margin-bottom: 0;
-    }
-
     .event-metadata td {
         padding-bottom: 3px;
 
@@ -120,17 +116,12 @@
     }
 
     .event-new-participants {
-        max-width: 458px;
-    }
-
-    .save-participants-form {
-        position: relative;
+        max-height: 120px;
     }
 
     .save-participants-btn {
-        left: 0;
-        position: absolute;
-        top: 0;
+        // Move the save button down to line up with the textarea to its left.
+        margin-top: 25px;
     }
 
     .event-revisions {

--- a/app/Resources/views/events/_participants.html.twig
+++ b/app/Resources/views/events/_participants.html.twig
@@ -7,64 +7,67 @@
         {# Valid participants should be shown below invalid ones. #}
         {% set validParticipants = [] %}
 
-        {{ form_start(form, {'method': 'post', 'attr': {'class': 'form-horizontal save-participants-form', 'autocomplete': 'off'}}) }}
-        {% for participant in form.participants %}
-            {% set invalidParticipant = false %}
-            {% if not(participant.vars.valid) %}
-                {% set invalidParticipant = true %}
-            {% endif %}
-
-            {% set participantRow %}
-                <div class="form-group participant-row{% if invalidParticipant %} has-error{% endif %}">
-                    <div class="col-sm-4">
-                        {{ form_widget(participant, {'attr': {'class': 'user-input'}}) }}
-                        {% if invalidParticipant %}
-                            <span class="font-awesome invalid-input">&#xf071;</span>
-                        {% else %}
-                            <span class="font-awesome valid-input">&#xf05d;</span>
-                        {% endif %}
-                    </div>
-                    <div class="col-sm-2">
-                        <button type="button" class="btn btn-default remove-participant">
-                            {{ msg('remove') }}
-                        </button>
-                    </div>
-                </div>
-            {% endset %}
-
-            {##
-             # If invalid, show immediately, otherwise merge into valid ones that
-             # will show below the invalid ones.
-             #}
-            {% if invalidParticipant %}
-                {{ participantRow }}
-            {% else %}
-                {% set validParticipants = validParticipants|merge([participantRow]) %}
-            {% endif %}
-        {% endfor %}
-
-        {# Render valid participants. #}
-        {% for row in validParticipants %}
-            {{ row }}
-        {% endfor %}
-
-        <div class="col-sm-6 col-sm-offset-6 save-participants-btn">
-            {{ form_widget(form.submit, {'label': msg('save-participants'), 'attr': {'class': 'btn-primary'}}) }}
-        </div>
-
-        <div class="form-group col-sm-6 event-add-participants">
-            <label for="form_new_participants">{{ msg('add-more-participants') }}</label>
-            {{ form_widget(form.new_participants, {'attr': {'class': 'event-new-participants', 'rows': 10}}) }}
-        </div>
-        {% if form.participants|length == 0 %}
+        {{ form_start(form, {'method': 'post', 'attr': {'class': 'save-participants-form', 'autocomplete': 'off'}}) }}
+        <div class="row">
+            {# This form comprises two columns, the first for the participants list and fields, the 2nd for the submit button. #}
             <div class="col-sm-6">
+
+                <div class="form-group event-add-participants">
+                    <label for="form_new_participants">{{ msg('add-more-participants') }}</label>
+                    {{ form_widget(form.new_participants, {'attr': {'class': 'event-new-participants', 'rows': 10}}) }}
+                </div>
+
+                {% for participant in form.participants %}
+                    {% set invalidParticipant = false %}
+                    {% if not(participant.vars.valid) %}
+                        {% set invalidParticipant = true %}
+                    {% endif %}
+        
+                    {% set participantRow %}
+                        <div class="row participant-row{% if invalidParticipant %} has-error{% endif %}">
+                            <div class="col-sm-9 form-group">
+                                {{ form_widget(participant, {'attr': {'class': 'user-input'}}) }}
+                                {% if invalidParticipant %}
+                                    <span class="font-awesome invalid-input">&#xf071;</span>
+                                {% else %}
+                                    <span class="font-awesome valid-input">&#xf05d;</span>
+                                {% endif %}
+                            </div>
+                            <div class="col-sm-3">
+                                <button type="button" class="btn btn-default remove-participant form-control">
+                                    {{ msg('remove') }}
+                                </button>
+                            </div>
+                        </div>
+                    {% endset %}
+
+                    {##
+                     # If invalid, show immediately, otherwise merge into valid ones that
+                     # will show below the invalid ones.
+                     #}
+                    {% if invalidParticipant %}
+                        {{ participantRow }}
+                    {% else %}
+                        {% set validParticipants = validParticipants|merge([participantRow]) %}
+                    {% endif %}
+                {% endfor %}
+
+                {# Render valid participants. #}
+                {% for row in validParticipants %}
+                    {{ row }}
+                {% endfor %}
+
+            </div>{# End participants column. #}
+
+            <div class="col-sm-6 save-participants-btn">
                 {{ form_widget(form.submit, {'label': msg('save-participants'), 'attr': {'class': 'btn-primary'}}) }}
             </div>
-        {% endif %}
 
+        </div>{# End row #}
         {{ form_row(form._token) }}
         {{ form_end(form, {'render_rest': false}) }}
-    {% else %}
+
+    {% else %}{# if not the organizer #}
         {% for participant in event.participants %}
             <div class="participant-row">
                 {{ participant.username }}


### PR DESCRIPTION
But still list the invalid participants above the textarea. This
change also changes the participants form from being a horizontal
form (in Bootstrap parlance) and so adds .row divs where required;
this means some styling can be removed.

Bug: https://phabricator.wikimedia.org/T200544