### PR TITLE
[WiP] Fix Code Climate integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
 
 after_script:
   - ps -ef | grep communitytech@tools-dev.wmflabs.org | awk 'NR==1{print $3}' | xargs kill -9
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A Wikimedia Foundation tool that provides grantees a simple, easy to use interfa
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Build Status](https://travis-ci.org/wikimedia/grantmetrics.svg?branch=master)](https://travis-ci.org/wikimedia/grantmetrics)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/test_coverage)](https://codeclimate.com/github/codeclimate/codeclimate/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/codeclimate/codeclimate/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/53b3ddf0ce654055f8cd/test_coverage)](https://codeclimate.com/github/wikimedia/grantmetrics/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/53b3ddf0ce654055f8cd/maintainability)](https://codeclimate.com/github/wikimedia/grantmetrics/maintainability)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/wikimedia/grantmetrics/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/wikimedia/grantmetrics/?branch=master)
 
 ## Installation for development

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
             "php phpDocumentor.phar -d src -t docs/api --template='checkstyle' --ansi --force && ( [[ -z $(grep 'error' docs/api/checkstyle.xml) ]] )"
         ],
         "unit": [
-            "./vendor/bin/simple-phpunit tests"
+            "./vendor/bin/simple-phpunit --coverage-clover ./clover.xml tests"
         ],
         "test": [
             "@migrate-test",


### PR DESCRIPTION
Just investigating this:

> $ ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
> Error: could not find any viable formatter. available formatters: clover, cobertura, coverage.py, excoveralls, gcov, gocov, jacoco, lcov, simplecov

And also the badge URLs.