### PR TITLE
Remove high unicode characters from model titles

### DIFF
--- a/app/Resources/assets/js/application.js
+++ b/app/Resources/assets/js/application.js
@@ -187,3 +187,16 @@ function setupColumnSorting()
         $table.find('tbody').html($(entries));
     });
 }
+
+/**
+ * Prevent the insertion of emojis etc.
+ * See also TitleUserTrait::setTitle() for the same replacement being made server-side.
+ */
+$(function () {
+    function replaceHighUtf8Strings()
+    {
+        var newVal = $(this).val().replace(/[\u{010000}-\u{10FFFF}]/gu, String.fromCodePoint(0xFFFD));
+        $(this).val(newVal);
+    }
+    $('input, textarea').on({ keydown: replaceHighUtf8Strings, change: replaceHighUtf8Strings });
+});

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -31,7 +31,7 @@ framework:
     fragments: ~
     http_method_override: true
     assets:
-        version: '6'
+        version: '7'
         version_format: '%%s?v=%%s'
     php_errors:
         log: true

--- a/src/AppBundle/Model/Traits/TitleUserTrait.php
+++ b/src/AppBundle/Model/Traits/TitleUserTrait.php
@@ -51,6 +51,10 @@ trait TitleUserTrait
      */
     public function setTitle($title)
     {
+        // Remove 4-byte unicode characters (replace with the "replacement character" �).
+        // Kudos https://stackoverflow.com/a/24672780
+        // More info http://unicode.org/reports/tr36/#Deletion_of_Noncharacters
+        $title = preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $title);
         // Use underscores instead of spaces.
         $this->title = str_replace(' ', '_', trim($title));
     }


### PR DESCRIPTION
This replaces 4-byte utf8 characters (i.e. emojis, basically) in
model titles with the unicode replacement character.

Bug: https://phabricator.wikimedia.org/T201388