### PR TITLE
API endpoint to get all wikis adhering to EventWiki::VALID_WIKI_PATTERN

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         ]
     },
     "require": {
+        "ext-json": "*",
         "php": "^5.6|^7.0",
         "Krinkle/intuition": "^0.6.1",
         "doctrine/doctrine-bundle": "^1.6",

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -5,6 +5,9 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Model\EventWiki;
+use AppBundle\Repository\EventWikiRepository;
+use Doctrine\ORM\EntityManager;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -198,5 +201,28 @@ class DefaultController extends Controller
     {
         $this->get('session')->invalidate();
         return $this->redirectToRoute('homepage');
+    }
+
+    /*****************
+     * API ENDPOINTS *
+     *****************/
+
+    /**
+     * Get all wikis available on the replicas. This is used by the frontend for autocompletion when entering wikis.
+     * We do not use the Sitematrix API because (a) it's format is hard to parse, and moreover (b) newly introduced
+     * wikis may be in production but not on the replicas, which will cause Grant Metrics to error out.
+     * @Route("/api/wikis", name="WikisApi")
+     * @return JsonResponse
+     */
+    public function wikisApiAction()
+    {
+        /** @var EntityManager $em */
+        $em = $this->container->get('doctrine')->getManager();
+
+        /** @var EventWikiRepository $ewRepo */
+        $ewRepo = $em->getRepository(EventWiki::class);
+        $ewRepo->setContainer($this->container);
+
+        return $this->json($ewRepo->getAvailableWikis());
     }
 }

--- a/tests/AppBundle/Controller/DefaultControllerTest.php
+++ b/tests/AppBundle/Controller/DefaultControllerTest.php
@@ -53,10 +53,27 @@ class DefaultControllerTest extends DatabaseAwareWebTestCase
      */
     public function testOAuthCallback()
     {
-        $client = static::createClient();
-        $client->request('GET', '/oauth_callback');
+        $this->client->request('GET', '/oauth_callback');
 
         // Callback should 404 since we didn't give it anything.
-        static::assertEquals(404, $client->getResponse()->getStatusCode());
+        static::assertEquals(404, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * The wikis API.
+     */
+    public function testWikisApi()
+    {
+        $this->client->request('GET', '/api/wikis');
+        $this->response = $this->client->getResponse();
+
+        static::assertArraySubset(
+            [
+                'de.wikipedia' => 'dewiki_p',
+                'www.wikidata' => 'wikidatawiki_p',
+                'commons.wikimedia' => 'commonswiki_p',
+            ],
+            json_decode($this->response->getContent(), true)
+        );
     }
 }


### PR DESCRIPTION
This will be used in clientside JavaScript for autocompletion on wiki
inputs. We can't go by the Sitematrix API because newly introduced wikis
may be production but not yet on the replicas, causing Grant Metrics to
error out.

This commit also adds ext-json as a dependency in composer.json, along
with some unrelated minor code aesthetics.