### PR TITLE
[WIP] Add CategorySubscriber to handle title/ids; add some getters/setters/counters on Event and EventWiki

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -34,6 +34,11 @@ services:
             - { name: doctrine.event_listener, event: postLoad }
             - { name: doctrine.event_listener, event: prePersist }
 
+    AppBundle\EventSubscriber\CategorySubscriber:
+        tags:
+            - { name: doctrine.event_listener, event: postLoad }
+            - { name: doctrine.event_listener, event: prePersist }
+
     AppBundle\EventSubscriber\ProgramSubscriber:
         tags:
             - { name: doctrine.event_listener, event: postLoad }

--- a/src/AppBundle/EventSubscriber/CategorySubscriber.php
+++ b/src/AppBundle/EventSubscriber/CategorySubscriber.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This file contains only the CategorySubscriber class.
+ */
+
+namespace AppBundle\EventSubscriber;
+
+use AppBundle\Model\EventCategory;
+use AppBundle\Model\EventWiki;
+use AppBundle\Repository\EventCategoryRepository;
+use AppBundle\Repository\EventWikiRepository;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Serializer\Tests\Model;
+
+/**
+ * CategorySubscriber automatically sets the title on categories from the replicas, after the Entity is loaded from
+ * the grantmetrics database. Similarly it will automatically set the category_id when an EventCategory is persisted.
+ */
+class CategorySubscriber
+{
+    /** @var ContainerInterface The application's container interface. */
+    private $container;
+
+    /**
+     * Constructor for CategorySubscriber.
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * This is automatically called by Doctrine when loading an entity, or directly with EventManager::dispatchEvent().
+     * @param LifecycleEventArgs $event Doctrine lifecycle event arguments.
+     */
+    public function postLoad(LifecycleEventArgs $event)
+    {
+        /** @var Model $entity One of the AppBundle\Model classes. */
+        $entity = $event->getEntity();
+        if (!($entity instanceof EventCategory)) {
+            return;
+        }
+
+        /** @var EventWikiRepository $repo */
+        $ewRepo = $this->getRepository($event, EventWiki::class);
+
+        /** @var EventWiki $ew */
+        $ew = $entity->getWiki();
+        $ew->setDbName($ewRepo->getDbName($ew));
+
+        $title = $this->getRepository($event)
+            ->getCategoryNameFromId($ew->getDbName(), $entity->getCategoryId());
+        $entity->setTitle(str_replace('_', ' ', $title));
+    }
+
+    /**
+     * Set the category ID on the EventCategory for display purposes.
+     * @param LifecycleEventArgs $event Doctrine lifecycle event arguments.
+     */
+    public function prePersist(LifecycleEventArgs $event)
+    {
+        /** @var Model $entity One of the AppBundle\Model classes. */
+        $entity = $event->getEntity();
+        if (!($entity instanceof EventCategory) || is_int($entity->getCategoryId())) {
+            return;
+        }
+
+        /** @var EventWiki $wiki */
+        $wiki = $entity->getWiki();
+
+        // The dbName may already be set from the postLoad hook. This check just prevents redundant querying.
+        if (null === $wiki->getDbName()) {
+            /** @var EventWikiRepository $repo */
+            $ewRepo = $this->getRepository($event, EventWiki::class);
+            $wiki->setDbName($ewRepo->getDbName($wiki));
+        }
+
+        $categoryTitle = str_replace(' ', '_', trim($entity->getTitle()));
+        $categoryId = $this->getRepository($event)
+            ->getCategoryIdFromName($wiki->getDbName(), $categoryTitle);
+        $entity->setCategoryId($categoryId);
+    }
+
+    /**
+     * Get the entity and corresponding Repository, given the lifecycle event.
+     * @param LifecycleEventArgs $event
+     * @param string $class Which class to get a Repository for.
+     * @return EventCategoryRepository|EventWikiRepository
+     */
+    private function getRepository(LifecycleEventArgs $event, $class = EventCategory::class)
+    {
+        /** @var EntityManager $em */
+        $em = $event->getEntityManager();
+
+        /** @var EventCategoryRepository $repo */
+        $repo = $em->getRepository($class);
+        $repo->setContainer($this->container);
+
+        return $repo;
+    }
+}

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -365,6 +365,23 @@ class Event
      **************/
 
     /**
+     * Get categories set on EventWikis associated with this Event.
+     * @return ArrayCollection of EventCategories.
+     */
+    public function getCategories()
+    {
+        /** @var EventCategory[] $categories */
+        $categories = [];
+
+        // Orphan and children only. Categories can't be assigned to *.wikipedia, etc.
+        foreach ($this->getOrphanAndChildWikis() as $wiki) {
+            $categories = array_merge($categories, $wiki->getCategories()->toArray());
+        }
+
+        return new ArrayCollection($categories);
+    }
+
+    /**
      * Are there any categories set on EventWikis associated with this Event?
      * @return bool
      */
@@ -376,6 +393,17 @@ class Event
             }
         }
         return false;
+    }
+
+    /**
+     * Get the number of categories associated with this Event, across all EventWikis.
+     * @return int
+     */
+    public function getNumCategories()
+    {
+        return array_sum($this->getWikis()->map(function (EventWiki $wiki) {
+            return count($wiki->getCategories());
+        })->toArray());
     }
 
     /****************
@@ -575,6 +603,18 @@ class Event
             return null === $wiki->getDomain()
                 || !$familyNames->contains($wiki->getFamilyName());
         });
+    }
+
+    /**
+     * Get child and orphan wikis.
+     * @return ArrayCollection of EventWikis.
+     */
+    public function getOrphanAndChildWikis()
+    {
+        return new ArrayCollection(array_merge(
+            $this->getChildWikis()->toArray(),
+            $this->getOrphanWikis()->toArray()
+        ));
     }
 
     /**

--- a/src/AppBundle/Model/EventCategory.php
+++ b/src/AppBundle/Model/EventCategory.php
@@ -53,11 +53,16 @@ class EventCategory
     protected $categoryId;
 
     /**
+     * @var string Category title fetched from the ID.
+     */
+    protected $title;
+
+    /**
      * EventCategory constructor.
      * @param EventWiki $wiki
-     * @param int $categoryId
+     * @param int|null $categoryId
      */
-    public function __construct(EventWiki $wiki, $categoryId)
+    public function __construct(EventWiki $wiki, $categoryId = null)
     {
         $this->wiki = $wiki;
         $this->wiki->addCategory($this);
@@ -83,11 +88,38 @@ class EventCategory
     }
 
     /**
+     * Set the ID of the category in the MediaWiki database.
+     * @param int $id
+     */
+    public function setCategoryId($id)
+    {
+        $this->categoryId = $id;
+    }
+
+    /**
      * ID of the category in the MediaWiki database.
      * @return int
      */
     public function getCategoryId()
     {
         return $this->categoryId;
+    }
+
+    /**
+     * Set the title of the category. This value is not persisted to the database.
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Get the title of the category.
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
     }
 }

--- a/src/AppBundle/Model/EventWiki.php
+++ b/src/AppBundle/Model/EventWiki.php
@@ -67,6 +67,13 @@ class EventWiki
     protected $domain;
 
     /**
+     * The database name of the wiki. This is not persisted but can be stored here for convenience when
+     * passing around EventWikis and running queries on them.
+     * @var string
+     */
+    protected $dbName;
+
+    /**
      * One EventWiki has many EventStats.
      * @ORM\OneToMany(targetEntity="EventWikiStat", mappedBy="wiki", orphanRemoval=true, cascade={"persist"})
      * @var ArrayCollection|EventStat[] Statistics for this EventWiki.
@@ -110,6 +117,24 @@ class EventWiki
     public function getDomain()
     {
         return $this->domain;
+    }
+
+    /**
+     * Get the database name of the wiki, if it has been provided.
+     * @return string
+     */
+    public function getDbName()
+    {
+        return $this->dbName;
+    }
+
+    /**
+     * Set the database name of the wiki.
+     * @param $dbName
+     */
+    public function setDbName($dbName)
+    {
+        $this->dbName = $dbName;
     }
 
     /**

--- a/tests/AppBundle/EventSubscriber/CategorySubscriberTest.php
+++ b/tests/AppBundle/EventSubscriber/CategorySubscriberTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This file contains only the CategorySubscriberTest class.
+ */
+
+namespace Tests\AppBundle\EventSubscriber;
+
+use AppBundle\DataFixtures\ORM\LoadFixtures;
+use AppBundle\Model\Event;
+use AppBundle\Model\EventCategory;
+use AppBundle\Model\EventWiki;
+use Tests\AppBundle\Controller\DatabaseAwareWebTestCase;
+
+/**
+ * Class CategorySubscriberTest
+ */
+class CategorySubscriberTest extends DatabaseAwareWebTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->addFixture(new LoadFixtures('extended'));
+        $this->executeFixtures();
+    }
+
+    /**
+     * Persisting categories to the grantmetrics database.
+     * @covers \AppBundle\EventSubscriber\CategorySubscriber::prePersist()
+     */
+    public function testPrePersist()
+    {
+        /** @var Event $event */
+        $event = $this->entityManager
+            ->getRepository('Model:Event')
+            ->findOneBy(['title' => 'Oliver_and_Company']);
+
+        /** @var EventWiki $eventWiki */
+        $eventWiki = $event->getWikiByDomain('en.wikipedia');
+
+        $category = new EventCategory($eventWiki);
+        $category->setTitle('  Living_people  ');
+
+        $this->entityManager->persist($event);
+
+        // 173 = Living_people
+        static::assertEquals(173, $category->getCategoryId());
+
+        // Flush so that self::postLoadSpec() will have a category in the database to fetch.
+        $this->entityManager->flush();
+        $this->entityManager->clear(); // Forces future findBy's to fetch from database instead of cache.
+        $this->postLoadSpec();
+    }
+
+    /**
+     * Loading categories from the grantmetrics database. This is not a separate test case because it uses the
+     * EventCategory created by self::testPrePersist(), which would otherwise get erased.
+     * @covers \AppBundle\EventSubscriber\CategorySubscriber::postLoad()
+     */
+    public function postLoadSpec()
+    {
+        /** @var Event $event */
+        $event = $this->entityManager
+            ->getRepository('Model:Event')
+            ->findOneBy(['title' => 'Oliver_and_Company']);
+
+        // For good measure.
+        static::assertEquals(1, $event->getNumCategories());
+
+        /** @var EventCategory $category */
+        $category = $event->getCategories()->first();
+
+        static::assertEquals('Living people', $category->getTitle());
+    }
+}

--- a/tests/AppBundle/Model/EventCategoryTest.php
+++ b/tests/AppBundle/Model/EventCategoryTest.php
@@ -36,12 +36,18 @@ class EventCategoryTest extends GrantMetricsTestCase
 
         static::assertFalse($event->hasCategories());
 
-        $eventCategory = new EventCategory($wiki, 500);
+        $eventCategory = new EventCategory($wiki);
+        $eventCategory->setTitle('Foo bar');
+        $eventCategory->setCategoryId(500);
 
         static::assertTrue($event->hasCategories());
+        static::assertCount(1, $event->getCategories());
+        static::assertEquals(1, $event->getNumCategories());
 
         // Getters.
         static::assertEquals($event, $eventCategory->getEvent());
         static::assertEquals($wiki, $eventCategory->getWiki());
+        static::assertEquals('Foo bar', $eventCategory->getTitle());
+        static::assertEquals(500, $eventCategory->getCategoryId());
     }
 }

--- a/tests/AppBundle/Model/EventTest.php
+++ b/tests/AppBundle/Model/EventTest.php
@@ -323,6 +323,11 @@ class EventTest extends GrantMetricsTestCase
             array_values($event->getOrphanWikisAndFamilies()->toArray())
         );
 
+        static::assertEquals(
+            [$child, $orphan],
+            array_values($event->getOrphanAndChildWikis()->toArray())
+        );
+
         static::assertEquals([$child], array_values($event->getChildWikis()->toArray()));
         $event->clearChildWikis();
         static::assertEquals(0, $event->getChildWikis()->count());

--- a/tests/AppBundle/Model/EventWikiTest.php
+++ b/tests/AppBundle/Model/EventWikiTest.php
@@ -55,6 +55,10 @@ class EventWikiTest extends GrantMetricsTestCase
 
         // Make sure the association was made on the Event object, too.
         static::assertEquals($wiki, $this->event->getWikis()[0]);
+
+        // Basic setters/getters.
+        $wiki->setDbName('enwiki_p');
+        static::assertEquals('enwiki_p', $wiki->getDbName());
     }
 
     /**


### PR DESCRIPTION
**This pull request is a part of #95**

Add CategorySubscriber to set title/ids on ORM load/persist

Add a getter and counter of categories on an Event.

Add a dbName property to EventWiki, so that it can be cached and
used when running queries.