### PR TITLE
Improve phpdoc installation and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,13 @@
 /public/fonts/
 /output/
 /docs/api/
+/public/docs/
+/build/api-cache/
 /.idea/
 
 *.swp
 .DS_Store
 i18n_helper.js
 phpDocumentor.phar*
+/bin/phpdoc*
+

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -9,6 +9,7 @@
     <exclude-pattern>public_html/</exclude-pattern>
     <exclude-pattern>*.min.js</exclude-pattern>
     <exclude-pattern>app/DoctrineMigrations/</exclude-pattern>
+    <exclude-pattern>build/api-cache</exclude-pattern>
 
     <rule ref="Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps">
         <exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ before_install:
   - sudo apt-get install expect
   - chmod +x ./build/ci/ssh-tunnel.sh
   - ./build/ci/ssh-tunnel.sh
-  - wget https://github.com/phpDocumentor/phpDocumentor2/releases/download/v3.0.0-alpha.2-nightly-gdff5545/phpDocumentor.phar
-  - wget https://github.com/phpDocumentor/phpDocumentor2/releases/download/v3.0.0-alpha.2-nightly-gdff5545/phpDocumentor.phar.pubkey
+  #- ./build/phpdoc-install.php # Disabled until we need PhpDocumentor, see below.
   - phpenv config-rm xdebug.ini # ran before installing ext-redis
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini # Install ext-redis
 
@@ -41,7 +40,7 @@ before_script:
 
 script:
   - composer lint
-  - php phpDocumentor.phar run -d src -t docs/api --template="checkstyle" # Different than `composer docs` for CI build.
+  #- composer docs # Disabled for now, until PhpDocumentor 3 supports checkstyle again.
   - composer unit
 
 after_script:

--- a/build/phpdoc-install.php
+++ b/build/phpdoc-install.php
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+/**
+ * This file is called from composer.json and .travis.yml to install phpdoc in the bin directory.
+ * @file
+ */
+
+$phpdocBin = dirname(__DIR__).'/bin/phpdoc';
+if (!file_exists($phpdocBin)) {
+    echo "Downloading phpdoc to bin/phpdoc\n";
+    $release = 'v3.0.0-alpha.2-nightly-g46e6b49';
+    $releaseUrl = "https://github.com/phpDocumentor/phpDocumentor2/releases/download/$release/phpDocumentor.phar";
+    copy($releaseUrl, $phpdocBin);
+    copy($releaseUrl.'.pubkey', $phpdocBin.'.pubkey');
+}
+if (!is_executable($phpdocBin)) {
+    chmod($phpdocBin, 0700);
+}

--- a/composer.json
+++ b/composer.json
@@ -72,8 +72,8 @@
             "./vendor/bin/phpcs -s ."
         ],
         "docs": [
-            "{ [[ ! -f 'phpDocumentor.phar' ]] && curl -L https://github.com/phpDocumentor/phpDocumentor2/releases/download/v2.9.0/phpDocumentor.phar --output phpDocumentor.phar; } || true",
-            "php phpDocumentor.phar -d src -t docs/api --template='checkstyle' --ansi --force && ( [[ -z $(grep 'error' docs/api/checkstyle.xml) ]] )"
+            "build/phpdoc-install.php",
+            "bin/phpdoc run --title='GrantMetrics Documentation'"
         ],
         "unit": [
             "./vendor/bin/phpunit --coverage-clover ./clover.xml tests"

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor>
+    <!--
+    For some reason, in the beta of phpdoc 3 this title is being ignored,
+    so we're setting it in composer.json instead.
+    -->
+    <title>GrantMetrics Documentation</title>
+    <parser>
+        <target>var/docs-cache</target>
+        <default-package-name>Wikimedia/GrantMetrics</default-package-name>
+        <markers>
+            <item>TODO</item>
+            <item>FIXME</item>
+            <item>HACK</item>
+        </markers>
+        <extensions>
+            <extension>php</extension>
+            <extension>js</extension>
+        </extensions>
+    </parser>
+    <transformer>
+        <target>public/docs/</target>
+    </transformer>
+    <transformations>
+        <template name="clean" />
+        <template name="checkstyle" />
+    </transformations>
+    <files>
+        <directory>app</directory>
+        <directory>src</directory>
+        <directory>tests</directory>
+        <directory>public</directory>
+    </files>
+</phpdocumentor>


### PR DESCRIPTION
Temporarily removing phpdoc checkstyle from Travis CI because it
wasn't checking correctly anyway (was always successful).

Moved other phpdoc config into phpdoc.dist.xml