### PR TITLE
Make PHP classes strict; use scalar type hints and return types

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -35,7 +35,7 @@ services:
             - [setValidator, ['@validator']]
         tags: ['controller.service_arguments']
 
-    AppBundle\EventSubscriber\UserSubscriber:
+    AppBundle\EventSubscriber\OrganizerSubscriber:
         tags:
             - { name: doctrine.event_listener, event: postLoad }
             - { name: doctrine.event_listener, event: prePersist }

--- a/src/AppBundle/Controller/Controller.php
+++ b/src/AppBundle/Controller/Controller.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file contains only the Controller abstract class.
+ */
+
+declare(strict_types=1);
 
 namespace AppBundle\Controller;
 
@@ -9,7 +14,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * This is the parent Controller for all controllers in this application.
@@ -38,7 +42,6 @@ abstract class Controller extends SymfonyController
      * @param ContainerInterface $container
      * @param SessionInterface $session
      * @param EntityManagerInterface $em
-     * @param ValidatorInterface $validator
      * @param Intuition $intuition
      */
     public function __construct(
@@ -61,7 +64,7 @@ abstract class Controller extends SymfonyController
      * @param string $messageName
      * @param array $vars
      */
-    public function addFlashMessage(string $type, string $messageName, array $vars = [])
+    public function addFlashMessage(string $type, string $messageName, array $vars = []): void
     {
         $options = [
             'domain' => 'grantmetrics',

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -3,6 +3,8 @@
  * This file contains only the DefaultController class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Controller;
 
 use AppBundle\Repository\EventWikiRepository;
@@ -212,7 +214,7 @@ class DefaultController extends Controller
      * @param EventWikiRepository $ewRepo
      * @return JsonResponse
      */
-    public function wikisApiAction(EventWikiRepository $ewRepo)
+    public function wikisApiAction(EventWikiRepository $ewRepo): JsonResponse
     {
         return $this->json($ewRepo->getAvailableWikis());
     }

--- a/src/AppBundle/Controller/EntityController.php
+++ b/src/AppBundle/Controller/EntityController.php
@@ -3,6 +3,8 @@
  * This file contains the abstract EntityController.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Controller;
 
 use AppBundle\Model\Event;
@@ -44,7 +46,6 @@ abstract class EntityController extends Controller
      * @param ContainerInterface $container
      * @param SessionInterface $session
      * @param EntityManagerInterface $em
-     * @param ValidatorInterface $validator
      * @param Intuition $intuition
      */
     public function __construct(
@@ -73,7 +74,7 @@ abstract class EntityController extends Controller
      * Check the request and if there are parameters for eventTitle or programTitle,
      * find and set class properties for the corresponding entity.
      */
-    private function setProgramAndEvent()
+    private function setProgramAndEvent(): void
     {
         $this->setProgram();
         $this->setEvent();
@@ -82,8 +83,9 @@ abstract class EntityController extends Controller
     /**
      * Check the request and if the programTitle is set, find and set
      * $this->program with the corresponding entity.
+     * @throws NotFoundHttpException
      */
-    private function setProgram()
+    private function setProgram(): void
     {
         $programTitle = $this->request->get('programTitle');
         if ($programTitle) {
@@ -99,8 +101,9 @@ abstract class EntityController extends Controller
     /**
      * Check the request and if the eventTitle is set, find and set
      * $this->event with the corresponding entity.
+     * @throws NotFoundHttpException
      */
-    private function setEvent()
+    private function setEvent(): void
     {
         $eventTitle = $this->request->get('eventTitle');
         if ($eventTitle) {
@@ -120,7 +123,7 @@ abstract class EntityController extends Controller
      * Get the Organizer based on username stored in the session.
      * @return Organizer
      */
-    protected function getOrganizer()
+    protected function getOrganizer(): Organizer
     {
         /** @var OrganizerRepository $organizerRepo */
         $organizerRepo = $this->em->getRepository(Organizer::class);
@@ -134,10 +137,10 @@ abstract class EntityController extends Controller
     /**
      * Is the logged in user an organizer of the given Program? This returns
      * true for admins, who are defined with the app.admins config parameter.
-     * @param  Program $program
+     * @param Program $program
      * @return bool
      */
-    protected function authUserIsOrganizer(Program $program)
+    protected function authUserIsOrganizer(Program $program): bool
     {
         $username = $this->session->get('logged_in_user')->username;
 
@@ -149,7 +152,7 @@ abstract class EntityController extends Controller
      * Is the current user an admin?
      * @return bool
      */
-    protected function userIsAdmin()
+    protected function userIsAdmin(): bool
     {
         $username = $this->session->get('logged_in_user')->username;
         return in_array($username, $this->container->getParameter('app.admins'));
@@ -160,7 +163,7 @@ abstract class EntityController extends Controller
      * and if not throw an exception (they should never be able to navigate here).
      * @throws AccessDeniedHttpException
      */
-    private function validateOrganizer()
+    private function validateOrganizer(): void
     {
         if (isset($this->program) && !$this->authUserIsOrganizer($this->program)) {
             throw new AccessDeniedHttpException('error-non-organizer');
@@ -171,7 +174,7 @@ abstract class EntityController extends Controller
      * Redirect to /login if the user is logged out.
      * @throws HttpException
      */
-    private function validateUser()
+    private function validateUser(): void
     {
         if ($this->session->get('logged_in_user') != '') {
             return;

--- a/src/AppBundle/Controller/EventDataController.php
+++ b/src/AppBundle/Controller/EventDataController.php
@@ -3,6 +3,8 @@
  * This file contains only the EventDataController class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Controller;
 
 use AppBundle\Model\Event;
@@ -29,9 +31,10 @@ class EventDataController extends EntityController
      * Lists individual revisions that make up the Event.
      * @Route("/programs/{programTitle}/{eventTitle}/revisions", name="Revisions")
      * @Route("/programs/{programTitle}/{eventTitle}/revisions/", name="RevisionsSlash")
+     * @param EventRepository $eventRepo
      * @return Response
      */
-    public function revisionsAction(EventRepository $eventRepo)
+    public function revisionsAction(EventRepository $eventRepo): Response
     {
         // Redirect to event page if statistics have not yet been generated.
         if (null === $this->event->getUpdated()) {
@@ -83,7 +86,7 @@ class EventDataController extends EntityController
      * @param array $ret Data that should be passed to the view.
      * @return Response
      */
-    private function getFormattedRevisionsResponse($format, array $ret)
+    private function getFormattedRevisionsResponse(string $format, array $ret): Response
     {
         $formatMap = [
             'wikitext' => 'text/plain',
@@ -110,13 +113,14 @@ class EventDataController extends EntityController
      * @Route("/events/process/{eventId}/", name="EventProcessSlash", requirements={"id" = "\d+"})
      * @param JobHandler $jobHandler The job handler service, provided by Symfony dependency injection.
      * @param int $eventId The ID of the event to process.
+     * @param EventRepository $eventRepo
      * @return JsonResponse
      * @throws AccessDeniedHttpException
      * @throws NotFoundHttpException
      * Coverage done on the ProcessEventCommand itself to avoid overhead of the request stack,
      * and also because this action can only be called via AJAX.
      */
-    public function generateStatsAction(JobHandler $jobHandler, $eventId, EventRepository $eventRepo)
+    public function generateStatsAction(JobHandler $jobHandler, int $eventId, EventRepository $eventRepo): JsonResponse
     {
         // Only respond to AJAX.
         if (!$this->request->isXmlHttpRequest()) {
@@ -162,7 +166,7 @@ class EventDataController extends EntityController
      * and also because this action can only be called via AJAX.
      * @codeCoverageIgnore
      */
-    private function createJobAndGetResponse(JobHandler $jobHandler, Event $event)
+    private function createJobAndGetResponse(JobHandler $jobHandler, Event $event): JsonResponse
     {
         // Create a new Job for the Event, and flush to the database.
         $job = new Job($event);

--- a/src/AppBundle/Controller/ProgramController.php
+++ b/src/AppBundle/Controller/ProgramController.php
@@ -3,6 +3,8 @@
  * This file contains only the ProgramController class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Controller;
 
 use AppBundle\Form\ProgramType;
@@ -27,7 +29,7 @@ class ProgramController extends EntityController
      * @param OrganizerRepository $organizerRepo
      * @return Response
      */
-    public function indexAction(ProgramRepository $programRepo, OrganizerRepository $organizerRepo)
+    public function indexAction(ProgramRepository $programRepo, OrganizerRepository $organizerRepo): Response
     {
         $organizer = $this->getOrganizer();
 
@@ -51,7 +53,7 @@ class ProgramController extends EntityController
      * @Route("/programs/new/", name="NewProgramSlash")
      * @return Response|RedirectResponse
      */
-    public function newAction()
+    public function newAction(): Response
     {
         $organizer = $this->getOrganizer();
         $program = new Program($organizer);
@@ -76,7 +78,7 @@ class ProgramController extends EntityController
      * @Route("/programs/edit/{programTitle}/", name="EditProgramSlash")
      * @return Response|RedirectResponse
      */
-    public function editAction()
+    public function editAction(): Response
     {
         // Handle the Form for the request, and redirect if they submitted.
         $form = $this->handleFormSubmission($this->program);
@@ -99,7 +101,7 @@ class ProgramController extends EntityController
      * @Route("/programs/delete/{programTitle}/", name="DeleteProgramSlash")
      * @return RedirectResponse
      */
-    public function deleteAction()
+    public function deleteAction(): RedirectResponse
     {
         // Flash message will be shown at the top of the page.
         $this->addFlashMessage('danger', 'program-deleted', [$this->program->getDisplayTitle()]);
@@ -117,7 +119,7 @@ class ProgramController extends EntityController
      * @param ProgramRepository $programRepo
      * @return Response
      */
-    public function showAction(ProgramRepository $programRepo)
+    public function showAction(ProgramRepository $programRepo): Response
     {
         return $this->render('programs/show.html.twig', [
             'program' => $this->program,

--- a/src/AppBundle/EventSubscriber/ExceptionSubscriber.php
+++ b/src/AppBundle/EventSubscriber/ExceptionSubscriber.php
@@ -3,6 +3,8 @@
  * This file contains only the ExceptionSubscriber class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\EventSubscriber;
 
 use Psr\Log\LoggerInterface;
@@ -45,7 +47,7 @@ class ExceptionSubscriber
      * @param GetResponseForExceptionEvent $event
      * @throws \Exception
      */
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelException(GetResponseForExceptionEvent $event): void
     {
         $exception = $event->getException();
 

--- a/src/AppBundle/EventSubscriber/OrganizerSubscriber.php
+++ b/src/AppBundle/EventSubscriber/OrganizerSubscriber.php
@@ -3,6 +3,8 @@
  * This file contains only the UserSubscriber class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\EventSubscriber;
 
 use Doctrine\ORM\EntityManager;
@@ -13,13 +15,13 @@ use AppBundle\Repository\Repository;
 use Symfony\Component\Serializer\Tests\Model;
 
 /**
- * UserSubscriber automatically sets the username on Organizers after the entity is loaded from the grantmetrics
+ * OrganizerSubscriber automatically sets the username on Organizers after the entity is loaded from the grantmetrics
  * database. Similarly it will automatically set the user_id when a Organizer is persisted.
  *
  * This class used to also do the same for Participant, but there can hundreds of these loaded at once,
  * so we instead run a single query to batch-fetch the usernames.
  */
-class UserSubscriber
+class OrganizerSubscriber
 {
     /** @var ContainerInterface The application's container interface. */
     private $container;
@@ -38,7 +40,7 @@ class UserSubscriber
      * or directly with EventManager::dispatchEvent().
      * @param LifecycleEventArgs $event Doctrine lifecycle event arguments.
      */
-    public function postLoad(LifecycleEventArgs $event)
+    public function postLoad(LifecycleEventArgs $event): void
     {
         /** @var Model $entity One of the AppBundle\Model classes. */
         $entity = $event->getEntity();
@@ -57,7 +59,7 @@ class UserSubscriber
      * Set the user ID on the Organizer.
      * @param LifecycleEventArgs $event Doctrine lifecycle event arguments.
      */
-    public function prePersist(LifecycleEventArgs $event)
+    public function prePersist(LifecycleEventArgs $event): void
     {
         /** @var Model $entity One of AppBundle\Model classes. */
         $entity = $event->getEntity();
@@ -83,7 +85,7 @@ class UserSubscriber
      * @param Organizer $entity
      * @param Repository $repo
      */
-    private function setUsername($entity, $repo)
+    private function setUsername($entity, $repo): void
     {
         $userId = $entity->getUserId();
         $username = $repo->getUsernameFromId($userId);
@@ -95,7 +97,7 @@ class UserSubscriber
      * @param Organizer $entity
      * @param Repository $repo
      */
-    private function setUserId($entity, $repo)
+    private function setUserId($entity, $repo): void
     {
         $username = $entity->getUsername();
         $userId = $repo->getUserIdFromName($username);
@@ -108,7 +110,7 @@ class UserSubscriber
      * @param LifecycleEventArgs $event
      * @return Repository
      */
-    private function getRepository($entity, LifecycleEventArgs $event)
+    private function getRepository($entity, LifecycleEventArgs $event): Repository
     {
         /** @var EntityManager $em */
         $em = $event->getEntityManager();

--- a/src/AppBundle/EventSubscriber/ProgramSubscriber.php
+++ b/src/AppBundle/EventSubscriber/ProgramSubscriber.php
@@ -3,6 +3,8 @@
  * This file contains only the ProgramSubscriber class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\EventSubscriber;
 
 use AppBundle\Model\Program;
@@ -31,7 +33,7 @@ class ProgramSubscriber
      * or directly with EventManager::dispatchEvent().
      * @param LifecycleEventArgs $lifecycleEvent Doctrine lifecycle event arguments.
      */
-    public function postLoad(LifecycleEventArgs $lifecycleEvent)
+    public function postLoad(LifecycleEventArgs $lifecycleEvent): void
     {
         $program = $lifecycleEvent->getEntity();
 

--- a/src/AppBundle/Form/EventType.php
+++ b/src/AppBundle/Form/EventType.php
@@ -107,7 +107,7 @@ class EventType extends AbstractType
      * Get options for the timezone dropdown, grouping by region and also prefixing each option with the region.
      * @return string[]
      */
-    private function getTimezones()
+    private function getTimezones(): array
     {
         $timezones = [
             'UTC' => 'UTC',
@@ -137,7 +137,7 @@ class EventType extends AbstractType
      * Normalize the form data before submitting.
      * @param FormEvent $formEvent
      */
-    public function onEventPreSubmit(FormEvent $formEvent)
+    public function onEventPreSubmit(FormEvent $formEvent): void
     {
         $event = $formEvent->getData();
 
@@ -152,7 +152,7 @@ class EventType extends AbstractType
      * @param Event $event
      * @return CallbackTransformer
      */
-    private function getWikiCallbackTransformer(Event $event)
+    private function getWikiCallbackTransformer(Event $event): CallbackTransformer
     {
         return new CallbackTransformer(
             // Transform to the form.
@@ -166,7 +166,7 @@ class EventType extends AbstractType
             // Transform from the form.
             function (array $wikis) use ($event) {
                 return array_filter(
-                    $this->normalizeEventWikis($wikis, $event, $this->ewRepo)
+                    $this->normalizeEventWikis($wikis, $event)
                 );
             }
         );
@@ -177,15 +177,14 @@ class EventType extends AbstractType
      * to the domain (en.wikipedia). This method then instantiates a new EventWiki if one did not already exist.
      * @param string[] $wikis As retrieved by the form.
      * @param Event $event
-     * @param EventWikiRepository $eventWikiRepo
      * @return EventWiki[]
      */
-    private function normalizeEventWikis($wikis, Event $event, EventWikiRepository $eventWikiRepo)
+    private function normalizeEventWikis(array $wikis, Event $event): array
     {
-        return array_map(function ($wiki) use ($event, $eventWikiRepo) {
-            $domain = $eventWikiRepo->getDomainFromEventWikiInput($wiki);
+        return array_map(function ($wiki) use ($event) {
+            $domain = $this->ewRepo->getDomainFromEventWikiInput($wiki);
 
-            $eventWiki = $eventWikiRepo->findOneBy([
+            $eventWiki = $this->ewRepo->findOneBy([
                 'event' => $event,
                 'domain' => $domain,
             ]);

--- a/src/AppBundle/Form/ProgramType.php
+++ b/src/AppBundle/Form/ProgramType.php
@@ -9,6 +9,7 @@ namespace AppBundle\Form;
 
 use AppBundle\Model\Organizer;
 use AppBundle\Repository\OrganizerRepository;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
@@ -65,20 +66,20 @@ class ProgramType extends AbstractType
      * and sets the user ID before persisting so that the username can be validated.
      * @return CallbackTransformer
      */
-    private function getCallbackTransformer()
+    private function getCallbackTransformer(): CallbackTransformer
     {
         return new CallbackTransformer(
             // Transform to the form.
-            function (Collection $organizerObjects) {
+            function (Collection $organizerObjects): array {
                 return array_map(function (Organizer $organizer) {
                     return $organizer->getUsername();
                 }, $organizerObjects->toArray());
             },
             // Transform from the form.
-            function (array $organizerNames) {
-                return array_map(function ($organizerName) {
+            function (array $organizerNames): Collection {
+                return (new ArrayCollection($organizerNames))->map(function (string $organizerName) {
                     return $this->organizerRepo->getOrganizerByUsername($organizerName);
-                }, $organizerNames);
+                });
             }
         );
     }

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -3,10 +3,13 @@
  * This file contains only the Event class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Model;
 
 use DateTime;
 use DateTimeZone;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -201,16 +204,16 @@ class Event
      * @see TitleUserTrait
      * @return string
      */
-    public function getUserClassName()
+    public function getUserClassName(): string
     {
         return 'Participant';
     }
 
     /**
      * Get the ID of the event.
-     * @return int
+     * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -220,7 +223,7 @@ class Event
      * used when making expensive queries against the replicas.
      * @return string
      */
-    public function getCacheKey()
+    public function getCacheKey(): string
     {
         return (string)$this->id;
     }
@@ -229,7 +232,7 @@ class Event
      * Is the Event valid? If false, statistics will not be able to be generated.
      * @return bool
      */
-    public function isValid()
+    public function isValid(): bool
     {
         return $this->wikis->count() > 0 &&
             $this->start !== null &&
@@ -246,7 +249,7 @@ class Event
      * Get the Program associated with this Event.
      * @return Program
      */
-    public function getProgram()
+    public function getProgram(): Program
     {
         return $this->program;
     }
@@ -257,9 +260,9 @@ class Event
 
     /**
      * Get the start date of this Event.
-     * @return DateTime
+     * @return DateTime|null
      */
-    public function getStart()
+    public function getStart(): ?DateTime
     {
         return $this->start;
     }
@@ -268,7 +271,7 @@ class Event
      * Set the start date of this Event.
      * @param DateTime|string|null $value
      */
-    public function setStart($value)
+    public function setStart($value): void
     {
         $this->assignDate('start', $value);
     }
@@ -277,7 +280,7 @@ class Event
      * Get the start date adjusted with the Event's timezone.
      * @return DateTime
      */
-    public function getStartWithTimezone()
+    public function getStartWithTimezone(): DateTime
     {
         $dateStr = $this->start->format('YmdHis');
         $dt = new DateTime($dateStr, new DateTimeZone($this->timezone));
@@ -287,9 +290,9 @@ class Event
 
     /**
      * Get the end date of this Event.
-     * @return DateTime
+     * @return DateTime|null
      */
-    public function getEnd()
+    public function getEnd(): ?DateTime
     {
         return $this->end;
     }
@@ -298,7 +301,7 @@ class Event
      * Get the end date adjusted with the Event's timezone.
      * @return DateTime
      */
-    public function getEndWithTimezone()
+    public function getEndWithTimezone(): DateTime
     {
         $dateStr = $this->end->format('YmdHis');
         $dt = new DateTime($dateStr, new DateTimeZone($this->timezone));
@@ -310,17 +313,17 @@ class Event
      * Set the end date of this Event.
      * @param DateTime|string|null $value
      */
-    public function setEnd($value)
+    public function setEnd($value): void
     {
         $this->assignDate('end', $value);
     }
 
     /**
      * Convert the given date argument to a DateTime and save to class property.
-     * @param  string $key 'start' or 'end'.
-     * @param  DateTime|string $value
+     * @param string $key 'start' or 'end'.
+     * @param DateTime|string $value
      */
-    private function assignDate($key, $value)
+    private function assignDate(string $key, $value): void
     {
         if ($value instanceof DateTime) {
             $this->{$key} = $value;
@@ -338,7 +341,7 @@ class Event
      * Get the end date of this Event.
      * @return string
      */
-    public function getTimezone()
+    public function getTimezone(): string
     {
         return $this->timezone;
     }
@@ -347,7 +350,7 @@ class Event
      * Get the display variant of the timezone.
      * @return string
      */
-    public function getDisplayTimezone()
+    public function getDisplayTimezone(): string
     {
         return str_replace('_', ' ', $this->timezone);
     }
@@ -356,7 +359,7 @@ class Event
      * Get the end date of this Event.
      * @param string $timezone Official timezone code within the tz database.
      */
-    public function setTimezone($timezone)
+    public function setTimezone(string $timezone): void
     {
         $this->timezone = $timezone;
     }
@@ -375,7 +378,7 @@ class Event
      * Get categories belonging to this Event.
      * @return ArrayCollection of EventCategories.
      */
-    public function getCategories()
+    public function getCategories(): Collection
     {
         return $this->categories;
     }
@@ -384,9 +387,9 @@ class Event
      * Get the number of categories belonging to this Event.
      * @return int
      */
-    public function getNumCategories()
+    public function getNumCategories(): int
     {
-        return count($this->categories);
+        return $this->categories->count();
     }
 
     /**
@@ -394,7 +397,7 @@ class Event
      * @param EventWiki $wiki
      * @return string[]
      */
-    public function getCategoryTitlesForWiki(EventWiki $wiki)
+    public function getCategoryTitlesForWiki(EventWiki $wiki): array
     {
         return $this->categories->filter(function (EventCategory $category) use ($wiki) {
             // First get EventCategories that are for the given EventWiki (have the same domain).
@@ -409,7 +412,7 @@ class Event
      * Add an EventCategory to the Event.
      * @param EventCategory $category
      */
-    public function addCategory(EventCategory $category)
+    public function addCategory(EventCategory $category): void
     {
         if ($this->categories->contains($category)) {
             return;
@@ -421,7 +424,7 @@ class Event
      * Remove an EventCategory from the Event.
      * @param EventCategory $category
      */
-    public function removeCategory(EventCategory $category)
+    public function removeCategory(EventCategory $category): void
     {
         if (!$this->categories->contains($category)) {
             return;
@@ -445,7 +448,7 @@ class Event
      * Get participants of this Event.
      * @return ArrayCollection of Participants.
      */
-    public function getParticipants()
+    public function getParticipants(): Collection
     {
         return $this->participants;
     }
@@ -454,16 +457,16 @@ class Event
      * Get the number of participants of this Event.
      * @return int
      */
-    public function getNumParticipants()
+    public function getNumParticipants(): int
     {
-        return count($this->participants);
+        return $this->participants->count();
     }
 
     /**
      * Add an Participant to this Event.
      * @param Participant $participant
      */
-    public function addParticipant(Participant $participant)
+    public function addParticipant(Participant $participant): void
     {
         if ($this->participants->contains($participant)) {
             return;
@@ -475,7 +478,7 @@ class Event
      * Remove a Participant from this Event.
      * @param Participant $participant
      */
-    public function removeParticipant(Participant $participant)
+    public function removeParticipant(Participant $participant): void
     {
         if (!$this->participants->contains($participant)) {
             return;
@@ -487,28 +490,28 @@ class Event
      * Get the user IDs of all the Participants of this Event.
      * @return int[]
      */
-    public function getParticipantIds()
+    public function getParticipantIds(): array
     {
-        return array_map(function (Participant $participant) {
+        return $this->participants->map(function (Participant $participant) {
             return $participant->getUserId();
-        }, $this->participants->toArray());
+        })->toArray();
     }
 
     /**
      * Get the usernames of the Participants of this Event.
      * @return string[]
      */
-    public function getParticipantNames()
+    public function getParticipantNames(): array
     {
-        return array_map(function (Participant $participant) {
+        return $this->participants->map(function (Participant $participant) {
             return $participant->getUsername();
-        }, $this->participants->toArray());
+        })->toArray();
     }
 
     /**
      * Remove all Participants.
      */
-    public function clearParticipants()
+    public function clearParticipants(): void
     {
         $this->participants->clear();
     }
@@ -521,17 +524,17 @@ class Event
      * Get wikis this event is taking place on.
      * @return ArrayCollection|EventWiki[]
      */
-    public function getWikis()
+    public function getWikis(): Collection
     {
         return $this->wikis;
     }
 
     /**
      * Get the EventWiki with the given domain that belongs to this Event.
-     * @param $domain
+     * @param string $domain
      * @return EventWiki
      */
-    public function getWikiByDomain($domain)
+    public function getWikiByDomain(string $domain): EventWiki
     {
         return $this->wikis->filter(function (EventWiki $wiki) use ($domain) {
             return $wiki->getDomain() === $domain;
@@ -542,7 +545,7 @@ class Event
      * Add an EventWiki to this Event.
      * @param EventWiki $wiki
      */
-    public function addWiki(EventWiki $wiki)
+    public function addWiki(EventWiki $wiki): void
     {
         if ($this->wikis->contains($wiki)) {
             return;
@@ -554,7 +557,7 @@ class Event
      * Remove an EventWiki from this Event.
      * @param EventWiki $wiki
      */
-    public function removeWiki(EventWiki $wiki)
+    public function removeWiki(EventWiki $wiki): void
     {
         if (!$this->wikis->contains($wiki)) {
             return;
@@ -571,10 +574,10 @@ class Event
      * a wiki family (*.wikipedia, *.wiktionary, etc).
      * @return ArrayCollection of EventWikis
      */
-    public function getFamilyWikis()
+    public function getFamilyWikis(): Collection
     {
         return $this->wikis->filter(function (EventWiki $wiki) {
-            return substr($wiki->getDomain(), 0, 2) === '*.';
+            return substr((string)$wiki->getDomain(), 0, 2) === '*.';
         });
     }
 
@@ -586,11 +589,11 @@ class Event
      * it is not included in the 'wikipedia' group.
      * @return array
      */
-    public function getWikisByFamily()
+    public function getWikisByFamily(): array
     {
         $wikisByFamily = [];
 
-        foreach ($this->wikis->toArray() as $wiki) {
+        foreach ($this->wikis->getIterator() as $wiki) {
             if ($wiki->isFamilyWiki()) {
                 continue;
             }
@@ -610,7 +613,7 @@ class Event
      * Get all associated EventWikis that belong to a family.
      * @return ArrayCollection of EventWikis
      */
-    public function getChildWikis()
+    public function getChildWikis(): Collection
     {
         return $this->wikis->filter(function (EventWiki $wiki) {
             return $wiki->isChildWiki();
@@ -624,7 +627,7 @@ class Event
      * will if there is not a *.wikipedia EventWiki.
      * @return ArrayCollection of EventWikis
      */
-    public function getOrphanWikis()
+    public function getOrphanWikis(): Collection
     {
         $familyNames = $this->getFamilyWikis()->map(function (EventWiki $eventWiki) {
             return $eventWiki->getFamilyName();
@@ -639,7 +642,7 @@ class Event
     /**
      * Remove all associated EventWikis that belong to a family.
      */
-    public function clearChildWikis()
+    public function clearChildWikis(): void
     {
         $children = $this->getChildWikis()->toArray();
         foreach ($children as $child) {
@@ -648,11 +651,10 @@ class Event
     }
 
     /**
-     * Get EventWikis that are represent a wiki family, or an individual wiki
-     * that is not part of a family.
+     * Get EventWikis that are represent a wiki family, or an individual wiki that is not part of a family.
      * @return ArrayCollection Containing EventWikis
      */
-    public function getOrphanWikisAndFamilies()
+    public function getOrphanWikisAndFamilies(): ArrayCollection
     {
         return new ArrayCollection(array_merge(
             $this->getFamilyWikis()->toArray(),
@@ -668,7 +670,7 @@ class Event
      * Add a Job for this Event.
      * @param Job $job
      */
-    public function addJob(Job $job)
+    public function addJob(Job $job): void
     {
         if ($this->jobs->contains($job)) {
             return;
@@ -678,28 +680,27 @@ class Event
 
     /**
      * Get jobs associated with this Event (in theory there should be only one).
-     * @return Job[]
+     * @return Collection of Jobs.
      */
-    public function getJobs()
+    public function getJobs(): Collection
     {
         return $this->jobs;
     }
 
     /**
-     * Get the number of jobs associated with this Event.
-     * (Ideally there'd only be one, but this is here just in case.)
+     * Get the number of jobs associated with this Event. (Ideally there'd only be one, but this is here just in case.)
      * @return int
      */
-    public function getNumJobs()
+    public function getNumJobs(): int
     {
-        return count($this->jobs);
+        return $this->jobs->count();
     }
 
     /**
      * Is there a job associated with this Event?
      * @return boolean
      */
-    public function hasJob()
+    public function hasJob(): bool
     {
         return $this->getNumJobs() > 0;
     }
@@ -707,7 +708,7 @@ class Event
     /**
      * Remove all Jobs from this Event.
      */
-    public function removeJobs()
+    public function removeJobs(): void
     {
         $this->jobs->clear();
     }

--- a/src/AppBundle/Model/EventCategory.php
+++ b/src/AppBundle/Model/EventCategory.php
@@ -81,7 +81,7 @@ class EventCategory
      * Get the Event this EventCategory belongs to.
      * @return Event
      */
-    public function getEvent()
+    public function getEvent(): Event
     {
         return $this->event;
     }
@@ -90,7 +90,7 @@ class EventCategory
      * Set the Event this EventCategory belongs to.
      * @param Event $event
      */
-    public function setEvent(Event $event)
+    public function setEvent(Event $event): void
     {
         $this->event = $event;
     }
@@ -99,7 +99,7 @@ class EventCategory
      * Get the wiki domain this EventCategory applies to.
      * @return string
      */
-    public function getDomain()
+    public function getDomain(): string
     {
         return $this->domain;
     }
@@ -108,16 +108,16 @@ class EventCategory
      * Set the wiki domain this EventCategory applies to.
      * @param string $domain
      */
-    public function setDomain(string $domain)
+    public function setDomain(string $domain): void
     {
         $this->domain = $domain;
     }
 
     /**
-     * Set the title of the category. This value is not persisted to the database.
+     * Set the title of the category.
      * @param string $title
      */
-    public function setTitle($title)
+    public function setTitle(string $title): void
     {
         // Use underscores instead of spaces, as they will have to be when querying the replicas.
         $this->title = str_replace(' ', '_', trim($title));
@@ -127,7 +127,7 @@ class EventCategory
      * Get the title of the category.
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -136,7 +136,7 @@ class EventCategory
      * Get the display variant of the program title.
      * @return string
      */
-    public function getDisplayTitle()
+    public function getDisplayTitle(): string
     {
         return str_replace('_', ' ', $this->title);
     }

--- a/src/AppBundle/Model/EventStat.php
+++ b/src/AppBundle/Model/EventStat.php
@@ -3,6 +3,8 @@
  * This file contains only the EventStat class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Model;
 
 use AppBundle\Model\Traits\StatTrait;
@@ -30,13 +32,9 @@ class EventStat
     use StatTrait;
 
     /**
-     * Allowed metric types. Keys are the i18n key for the metric, and is what
-     * is stored in the database. Values are the applicable wikis for that type
-     * of metric, with null meaning all wikis.
-     *
-     * These also serve as the defaults when no EventStats are associated with
-     * an Event, based on the configured wiki(s).
-     *
+     * Allowed metric types. Keys are the i18n key for the metric, and is what is stored in the database.
+     * Values are the applicable wikis for that type of metric, with null meaning all wikis. These also serve as the
+     * defaults when no EventStats are associated with an Event, based on the configured wiki(s).
      * @see StatTrait Shared methods that use this constant.
      */
     const METRIC_TYPES = [
@@ -99,7 +97,7 @@ class EventStat
      * @param mixed $value Value of the associated metric.
      * @param int $offset Offset value associated with the metric, such as number of days retention.
      */
-    public function __construct(Event $event, $metric, $value, $offset = null)
+    public function __construct(Event $event, string $metric, $value, $offset = null)
     {
         $this->event = $event;
         $this->event->addStatistic($this);
@@ -112,7 +110,7 @@ class EventStat
      * Get the Event this EventStat applies to.
      * @return Event
      */
-    public function getEvent()
+    public function getEvent(): Event
     {
         return $this->event;
     }

--- a/src/AppBundle/Model/EventWiki.php
+++ b/src/AppBundle/Model/EventWiki.php
@@ -3,15 +3,17 @@
  * This file contains only the EventWiki class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * An EventWiki belongs to an Event, and also connects an EventStat
- * to a specific wiki and event.
+ * An EventWiki belongs to an Event, and also connects an EventStat to a specific wiki and event.
  * @ORM\Entity
  * @ORM\Table(
  *     name="event_wiki",
@@ -90,16 +92,16 @@ class EventWiki
      * Get the Event this EventWiki belongs to.
      * @return Event
      */
-    public function getEvent()
+    public function getEvent(): Event
     {
         return $this->event;
     }
 
     /**
      * Get the domain name.
-     * @return string
+     * @return string|null
      */
-    public function getDomain()
+    public function getDomain(): ?string
     {
         return $this->domain;
     }
@@ -112,7 +114,7 @@ class EventWiki
      * No need to test a hard-coded string.
      * @codeCoverageIgnore
      */
-    public static function getValidPattern()
+    public static function getValidPattern(): string
     {
         return self::VALID_WIKI_PATTERN;
     }
@@ -125,7 +127,7 @@ class EventWiki
      * Does this EventWiki represent a wiki family? e.g. *.wikipedia, *.wiktionary
      * @return bool
      */
-    public function isFamilyWiki()
+    public function isFamilyWiki(): bool
     {
         return substr($this->domain, 0, 2) === '*.';
     }
@@ -134,7 +136,7 @@ class EventWiki
      * Get the family name of this wiki ('wikipedia', 'commons', etc.).
      * @return string|null
      */
-    public function getFamilyName()
+    public function getFamilyName(): ?string
     {
         foreach (self::FAMILY_NAMES as $family) {
             if (strpos($this->domain, $family) !== false) {
@@ -150,7 +152,7 @@ class EventWiki
      * If this EventWiki represents a family, return all EventWikis of the Event that belong to the family.
      * @return ArrayCollection of EventWikis
      */
-    public function getChildWikis()
+    public function getChildWikis(): Collection
     {
         if (!$this->isFamilyWiki()) {
             return new ArrayCollection([]);
@@ -169,7 +171,7 @@ class EventWiki
      * Is this EventWiki a child of a family EventWiki that belongs to the same Event?
      * @return bool
      */
-    public function isChildWiki()
+    public function isChildWiki(): bool
     {
         return !$this->isFamilyWiki() && !$this->event->getOrphanWikis()->contains($this);
     }
@@ -182,7 +184,7 @@ class EventWiki
      * Get statistics about this EventWiki.
      * @return ArrayCollection|EventWikiStat[]
      */
-    public function getStatistics()
+    public function getStatistics(): Collection
     {
         return $this->stats;
     }
@@ -192,19 +194,19 @@ class EventWiki
      * @param string $metric Name of metric, one of EventWikiStat::METRIC_TYPES.
      * @return EventWikiStat|null Null if no EventWikiStat with given metric was found.
      */
-    public function getStatistic($metric)
+    public function getStatistic(string $metric): ?EventWikiStat
     {
-        $ewStats = array_filter($this->stats->toArray(), function (EventWikiStat $stat) use ($metric) {
+        $ewStats = $this->stats->filter(function (EventWikiStat $stat) use ($metric) {
             return $stat->getMetric() === $metric;
         });
-        return count($ewStats) > 0 ? reset($ewStats) : null;
+        return $ewStats->count() > 0 ? $ewStats->first() : null;
     }
 
     /**
      * Add an EventWikiStat to this EventWiki.
      * @param EventWikiStat $eventWikiStat
      */
-    public function addStatistic(EventWikiStat $eventWikiStat)
+    public function addStatistic(EventWikiStat $eventWikiStat): void
     {
         if ($this->stats->contains($eventWikiStat)) {
             return;
@@ -216,7 +218,7 @@ class EventWiki
      * Remove an EventWikiStat from this EventWiki.
      * @param EventWikiStat $eventWikiStat
      */
-    public function removeStatistic(EventWikiStat $eventWikiStat)
+    public function removeStatistic(EventWikiStat $eventWikiStat): void
     {
         if (!$this->stats->contains($eventWikiStat)) {
             return;
@@ -227,7 +229,7 @@ class EventWiki
     /**
      * Clear all associated statistics.
      */
-    public function clearStatistics()
+    public function clearStatistics(): void
     {
         $this->stats->clear();
     }

--- a/src/AppBundle/Model/Job.php
+++ b/src/AppBundle/Model/Job.php
@@ -3,6 +3,8 @@
  * This file contains only the Job class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Model;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -67,9 +69,9 @@ class Job
 
     /**
      * Get the ID of this Job.
-     * @return int
+     * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -78,16 +80,16 @@ class Job
      * Get the Event this Job applies to.
      * @return Event
      */
-    public function getEvent()
+    public function getEvent(): Event
     {
         return $this->event;
     }
 
     /**
      * When the Job was submitted.
-     * @return DateTime
+     * @return DateTime|null
      */
-    public function getSubmitted()
+    public function getSubmitted(): ?DateTime
     {
         return $this->submitted;
     }
@@ -96,7 +98,7 @@ class Job
      * Whether or not the Job has been initiated by the daemon.
      * @return bool
      */
-    public function getStarted()
+    public function getStarted(): bool
     {
         return $this->started;
     }
@@ -105,7 +107,7 @@ class Job
      * Flag the Job as having been initiated, or false if specified.
      * @param bool $state
      */
-    public function setStarted($state = true)
+    public function setStarted(bool $state = true): void
     {
         $this->started = $state;
     }
@@ -114,7 +116,7 @@ class Job
      * Set the submitted attribute when persisting.
      * @ORM\PrePersist
      */
-    public function setSubmitted()
+    public function setSubmitted(): void
     {
         $this->submitted = new DateTime();
     }

--- a/src/AppBundle/Model/Organizer.php
+++ b/src/AppBundle/Model/Organizer.php
@@ -3,8 +3,11 @@
  * This file contains only the Organizer class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Model;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -71,9 +74,9 @@ class Organizer
 
     /**
      * Get the ID of the organizer.
-     * @return int
+     * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -82,7 +85,7 @@ class Organizer
      * Does this organizer already exists in the database?
      * @return bool
      */
-    public function exists()
+    public function exists(): bool
     {
         return isset($this->id);
     }
@@ -90,9 +93,9 @@ class Organizer
     /**
      * Get the user ID of the Organizer.
      * Corresponds with `gu_id` on `centralauth`.`globaluser`.
-     * @return int
+     * @return int|null
      */
-    public function getUserId()
+    public function getUserId(): ?int
     {
         return $this->userId;
     }
@@ -102,16 +105,16 @@ class Organizer
      * Corresponds with `gu_id` on `centralauth`.`globaluser`.
      * @param int $userId
      */
-    public function setUserId($userId)
+    public function setUserId(int $userId): void
     {
         $this->userId = $userId;
     }
 
     /**
      * Get the username.
-     * @return string
+     * @return string|null
      */
-    public function getUsername()
+    public function getUsername(): ?string
     {
         return $this->username;
     }
@@ -120,7 +123,7 @@ class Organizer
      * Set the username.
      * @param string $username
      */
-    public function setUsername($username)
+    public function setUsername(string $username)
     {
         $this->username = $username;
     }
@@ -129,7 +132,7 @@ class Organizer
      * Get a list of programs that this organizer oversees.
      * @return ArrayCollection|Program[]
      */
-    public function getPrograms()
+    public function getPrograms(): Collection
     {
         return $this->programs;
     }
@@ -138,7 +141,7 @@ class Organizer
      * Associate this Organizer with a program.
      * @param Program $program
      */
-    public function addProgram(Program $program)
+    public function addProgram(Program $program): void
     {
         if ($this->programs->contains($program)) {
             return;
@@ -151,7 +154,7 @@ class Organizer
      * Remove association of this Organizer with the given program.
      * @param Program $program
      */
-    public function removeProgram(Program $program)
+    public function removeProgram(Program $program): void
     {
         if (!$this->programs->contains($program)) {
             return;

--- a/src/AppBundle/Model/Participant.php
+++ b/src/AppBundle/Model/Participant.php
@@ -3,6 +3,8 @@
  * This file contains only the Participant class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Model;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -67,7 +69,7 @@ class Participant
      * @param Event $event Event the Participant is participating in.
      * @param int $userId ID of the user, corresponds with `centralauth`.`globaluser`.
      */
-    public function __construct(Event $event, $userId = null)
+    public function __construct(Event $event, int $userId = null)
     {
         $this->event = $event;
         $this->event->addParticipant($this);
@@ -76,16 +78,18 @@ class Participant
 
     /**
      * Get the Event the Participant is participating in.
+     * @return Event
      */
-    public function getEvent()
+    public function getEvent(): Event
     {
         return $this->event;
     }
 
     /**
      * Get the user ID of the Participant.
+     * @return int|null
      */
-    public function getUserId()
+    public function getUserId(): ?int
     {
         return $this->userId;
     }
@@ -95,16 +99,16 @@ class Participant
      * Corresponds with `gu_id` on `centralauth`.`globaluser`.
      * @param int $userId
      */
-    public function setUserId($userId)
+    public function setUserId(int $userId): void
     {
         $this->userId = $userId;
     }
 
     /**
      * Get the username.
-     * @return string
+     * @return string|null
      */
-    public function getUsername()
+    public function getUsername(): ?string
     {
         return $this->username;
     }
@@ -113,7 +117,7 @@ class Participant
      * Set the username.
      * @param string $username
      */
-    public function setUsername($username)
+    public function setUsername(string $username): void
     {
         $this->username = $username;
     }

--- a/src/AppBundle/Model/Traits/EventStatTrait.php
+++ b/src/AppBundle/Model/Traits/EventStatTrait.php
@@ -3,18 +3,25 @@
  * This file contains only the EventStatTrait trait.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Model\Traits;
 
 use AppBundle\Model\EventStat;
+use AppBundle\Model\EventWiki;
 use DateTime;
 use DateTimeZone;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 
 /**
- * The EventStatTrait contains methods dealing with statistics
- * of a specific Event. This class is chiefly to extract out
- * logic and move it to a dedicated file for readability.
- * (or show me the correct way to make that file less massive... :)
+ * The EventStatTrait contains methods dealing with statistics of a specific Event. This trait is chiefly to extract out
+ * logic and move it to a dedicated file for readability (or show me the correct way to make that file less massive :).
+ *
+ * These are here to assist IDE inspections, since the properties are defined in Event.
+ * @property ArrayCollection|EventStat[] $stats
+ * @property ArrayCollection|EventWiki[] $wikis
+ * @property DateTime $updated
  */
 trait EventStatTrait
 {
@@ -22,7 +29,7 @@ trait EventStatTrait
      * Get statistics about this Event.
      * @return ArrayCollection|EventStat[]
      */
-    public function getStatistics()
+    public function getStatistics(): Collection
     {
         return $this->stats;
     }
@@ -32,10 +39,10 @@ trait EventStatTrait
      * @param string $metric Name of metric, one of EventStat::METRIC_TYPES.
      * @return EventStat|null Null if no EventStat with given metric was found.
      */
-    public function getStatistic($metric)
+    public function getStatistic($metric): ?EventStat
     {
         /** @var ArrayCollection $ewStats of EventStats. */
-        $ewStats = $this->stats->filter(function ($stat) use ($metric) {
+        $ewStats = $this->stats->filter(function (EventStat $stat) use ($metric) {
             return $stat->getMetric() === $metric;
         });
         return $ewStats->count() > 0 ? $ewStats->first() : null;
@@ -45,7 +52,7 @@ trait EventStatTrait
      * Add an EventStat to this Event.
      * @param EventStat $eventStat
      */
-    public function addStatistic(EventStat $eventStat)
+    public function addStatistic(EventStat $eventStat): void
     {
         if ($this->stats->contains($eventStat)) {
             return;
@@ -57,7 +64,7 @@ trait EventStatTrait
      * Remove an eventStat from this Event.
      * @param EventStat $eventStat
      */
-    public function removeStatistic(EventStat $eventStat)
+    public function removeStatistic(EventStat $eventStat): void
     {
         if (!$this->stats->contains($eventStat)) {
             return;
@@ -66,26 +73,24 @@ trait EventStatTrait
     }
 
     /**
-     * Clear all associated statistics, including EventWikiStats,
-     * and set the updated attribute to null.
+     * Clear all associated statistics, including EventWikiStats, and set the updated attribute to null.
      */
-    public function clearStatistics()
+    public function clearStatistics(): void
     {
         $this->stats->clear();
         $this->setUpdated(null);
 
-        foreach ($this->wikis->toArray() as $wiki) {
+        foreach ($this->wikis->getIterator() as $wiki) {
             $wiki->clearStatistics();
         }
     }
 
     /**
-     * Get the metric types available to this event, based on associated wikis,
-     * and their default offset values.
+     * Get the metric types available to this event, based on associated wikis, and their default offset values.
      * @param string|null $family Only return metrics available to given wiki family.
      * @return array
      */
-    public function getAvailableMetrics($family = null)
+    public function getAvailableMetrics($family = null): array
     {
         $metricMap = self::WIKI_FAMILY_METRIC_MAP;
 
@@ -104,7 +109,7 @@ trait EventStatTrait
         }
 
         // Return as associative array with the offsets as the values.
-        return array_filter(self::AVAILABLE_METRICS, function ($offset, $metric) use ($metricKeys) {
+        return array_filter(self::AVAILABLE_METRICS, function ($offset, $metric) use ($metricKeys): bool {
             return in_array($metric, $metricKeys);
         }, ARRAY_FILTER_USE_BOTH);
     }
@@ -113,16 +118,16 @@ trait EventStatTrait
      * Get all metrics available to all events, regardless of associated wikis.
      * @return string[]
      */
-    public static function getAllAvailableMetrics()
+    public static function getAllAvailableMetrics(): array
     {
         return self::AVAILABLE_METRICS;
     }
 
     /**
      * Get the date of the last time the EventStat's were refreshed.
-     * @return DateTime
+     * @return DateTime|null
      */
-    public function getUpdated()
+    public function getUpdated(): ?DateTime
     {
         return $this->updated;
     }
@@ -131,7 +136,7 @@ trait EventStatTrait
      * Get the update at value adjusted with the Event's timezone.
      * @return DateTime
      */
-    public function getUpdatedWithTimezone()
+    public function getUpdatedWithTimezone(): DateTime
     {
         $this->updated->setTimezone(new DateTimeZone($this->timezone));
         return new DateTime(
@@ -141,11 +146,10 @@ trait EventStatTrait
     }
 
     /**
-     * Set the 'update' attribute, to be set after EventStats
-     * have been refreshed.
+     * Set the 'update' attribute, to be set after EventStats have been refreshed.
      * @param DateTime|null $datestamp
      */
-    public function setUpdated($datestamp)
+    public function setUpdated(?DateTime $datestamp): void
     {
         $this->updated = $datestamp;
     }

--- a/src/AppBundle/Model/Traits/StatTrait.php
+++ b/src/AppBundle/Model/Traits/StatTrait.php
@@ -3,22 +3,23 @@
  * This file contains only the StatTrait trait.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Model\Traits;
 
 use InvalidArgumentException;
 
 /**
- * The StatTrait contains shared logic between the EventStat
- * and EventWikiStat models.
+ * The StatTrait contains shared logic between the EventStat and EventWikiStat models.
  */
 trait StatTrait
 {
     /**
-     * Assign the metric to the class instance, throwing an exception
-     * if it is of an unknown type.
+     * Assign the metric to the class instance, throwing an exception if it is of an unknown type.
      * @param string $metric
+     * @throws InvalidArgumentException
      */
-    private function setMetric($metric)
+    private function setMetric(string $metric): void
     {
         if (!in_array($metric, self::METRIC_TYPES)) {
             throw new InvalidArgumentException(
@@ -32,7 +33,7 @@ trait StatTrait
      * Update the value associated with the EventStat.
      * @param mixed $value
      */
-    public function setValue($value)
+    public function setValue($value): void
     {
         $this->value = $value;
     }
@@ -41,17 +42,16 @@ trait StatTrait
      * Get the metric type of this EventStat.
      * @return string
      */
-    public function getMetric()
+    public function getMetric(): string
     {
         return $this->metric;
     }
 
     /**
-     * Get the metric offset for this EventWikiStat,
-     * such as the number of days for the retention.
-     * @return int
+     * Get the metric offset for this EventWikiStat, such as the number of days for the retention.
+     * @return int|null
      */
-    public function getOffset()
+    public function getOffset(): ?int
     {
         return $this->offset;
     }
@@ -71,7 +71,7 @@ trait StatTrait
      * @return string[]
      * @codeCoverageIgnore
      */
-    public static function getMetricTypes()
+    public static function getMetricTypes(): array
     {
         return self::METRIC_TYPES;
     }

--- a/src/AppBundle/Model/Traits/TitleUserTrait.php
+++ b/src/AppBundle/Model/Traits/TitleUserTrait.php
@@ -3,21 +3,21 @@
  * This file contains only the TitleUserTrait trait.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Model\Traits;
 
 use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * The TitleUserTrait refactors out common methods between
- * Program and Event. These methods pertain to titles of the entity,
- * and the associated user class (Organizer or Participant).
+ * The TitleUserTrait refactors out common methods between Program and Event. These methods pertain to titles of the
+ * entity, and the associated user class (Organizer or Participant).
  */
 trait TitleUserTrait
 {
     /**
-     * The class name of users associated with Events,
-     * either 'Organizer' or 'Participant'.
+     * The class name of users associated with Events, either 'Organizer' or 'Participant'.
      * @abstract
      * @return string
      */
@@ -29,9 +29,9 @@ trait TitleUserTrait
 
     /**
      * Get the title of this Program.
-     * @return string
+     * @return string|null
      */
-    public function getTitle()
+    public function getTitle(): ?string
     {
         return $this->title;
     }
@@ -40,16 +40,16 @@ trait TitleUserTrait
      * Get the display variant of the program title.
      * @return string
      */
-    public function getDisplayTitle()
+    public function getDisplayTitle(): string
     {
         return str_replace('_', ' ', $this->title);
     }
 
     /**
      * Set the title of this Program.
-     * @param string $title
+     * @param string|null $title
      */
-    public function setTitle($title)
+    public function setTitle(?string $title): void
     {
         // Remove 4-byte unicode characters (replace with the "replacement character" �).
         // Kudos https://stackoverflow.com/a/24672780
@@ -64,7 +64,7 @@ trait TitleUserTrait
      * @Assert\Callback
      * @param ExecutionContext $context Supplied by Symfony.
      */
-    public function validateUnreservedTitle(ExecutionContext $context)
+    public function validateUnreservedTitle(ExecutionContext $context): void
     {
         if (in_array($this->title, ['edit', 'new', 'delete', 'process', 'api', 'revisions'])) {
             $context->buildViolation('error-title-reserved')
@@ -80,7 +80,7 @@ trait TitleUserTrait
      * @Assert\Callback
      * @param ExecutionContext $context Supplied by Symfony.
      */
-    public function validateCharacters(ExecutionContext $context)
+    public function validateCharacters(ExecutionContext $context): void
     {
         if (preg_match('/[\/]/', $this->title) === 1) {
             $context->buildViolation('error-title-invalid-chars')
@@ -99,7 +99,7 @@ trait TitleUserTrait
      * @Assert\Callback
      * @param ExecutionContext $context Supplied by Symfony.
      */
-    public function validateUsers(ExecutionContext $context)
+    public function validateUsers(ExecutionContext $context): void
     {
         $userIds = $this->{'get'.$this->getUserClassName().'Ids'}();
         $numEmpty = count($userIds) - count(array_filter($userIds));

--- a/src/AppBundle/Repository/EventCategoryRepository.php
+++ b/src/AppBundle/Repository/EventCategoryRepository.php
@@ -3,6 +3,8 @@
  * This file contains only the EventCategoryRepository class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Repository;
 
 use AppBundle\Model\EventCategory;
@@ -20,7 +22,7 @@ class EventCategoryRepository extends Repository
      * Implements Repository::getEntityClass
      * @return string
      */
-    public function getEntityClass()
+    public function getEntityClass(): string
     {
         return EventCategory::class;
     }
@@ -33,7 +35,7 @@ class EventCategoryRepository extends Repository
      * @param int|null $limit Max number of pages. null for no limit, but only do this if used in a subquery.
      * @return array|QueryBuilder Page IDs or the QueryBuilder object.
      */
-    public function getPagesInCategories($dbName, array $titles, $queryBuilder = false, $limit = 20000)
+    public function getPagesInCategories($dbName, array $titles, bool $queryBuilder = false, ?int $limit = 20000)
     {
         $rqb = $this->getReplicaConnection()->createQueryBuilder();
         $rqb->select(['DISTINCT(cl_from)'])

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -3,6 +3,8 @@
  * This file contains only the EventRepository class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Repository;
 
 use AppBundle\Model\Event;
@@ -24,7 +26,7 @@ class EventRepository extends Repository
      * Implements Repository::getEntityClass
      * @return string
      */
-    public function getEntityClass()
+    public function getEntityClass(): string
     {
         return Event::class;
     }
@@ -34,7 +36,7 @@ class EventRepository extends Repository
      * @param Event $event The Event in question.
      * @return string[] Usernames of new editors.
      */
-    public function getNewEditors(Event $event)
+    public function getNewEditors(Event $event): array
     {
         $userIds = $event->getParticipantIds();
         $offset = Event::getAllAvailableMetrics()['new-editors'];
@@ -67,12 +69,12 @@ class EventRepository extends Repository
      * @return array With keys 'edited' and 'created'.
      */
     public function getNumPagesEdited(
-        $dbName,
+        string $dbName,
         DateTime $start,
         DateTime $end,
         array $usernames = [],
         array $categoryTitles = []
-    ) {
+    ): array {
         if (empty($usernames) && empty($categoryTitles)) {
             // FIXME: This should throw an Exception or something so we can print an error message.
             return [
@@ -130,7 +132,7 @@ class EventRepository extends Repository
      * @param string[] $usernames
      * @return int
      */
-    public function getFilesUploadedCommons(DateTime $start, DateTime $end, array $usernames)
+    public function getFilesUploadedCommons(DateTime $start, DateTime $end, array $usernames): int
     {
         $start = $start->format('YmdHis');
         $end = $end->format('YmdHis');
@@ -179,12 +181,11 @@ class EventRepository extends Repository
     }
 
     /**
-     * Get database names of wikis attached to the global accounts
-     * with the given usernames.
+     * Get database names of wikis attached to the global accounts with the given usernames.
      * @param string[] $usernames
      * @return string[]
      */
-    public function getCommonWikis($usernames)
+    public function getCommonWikis(array $usernames): array
     {
         $conn = $this->getCentralAuthConnection();
         $rqb = $conn->createQueryBuilder();
@@ -204,7 +205,7 @@ class EventRepository extends Repository
      * @param string $family
      * @return string[] Domain names in the format of lang.project, e.g. en.wiktionary
      */
-    public function getCommonLangWikiDomains(array $usernames, $family)
+    public function getCommonLangWikiDomains(array $usernames, $family): array
     {
         $conn = $this->getCentralAuthConnection();
         $rqb = $conn->createQueryBuilder();
@@ -229,7 +230,7 @@ class EventRepository extends Repository
      * @param string[] $usernames
      * @return string[]
      */
-    public function getUsersRetained($dbName, DateTime $start, array $usernames)
+    public function getUsersRetained(string $dbName, DateTime $start, array $usernames): array
     {
         $start = $start->format('YmdHis');
         $conn = $this->getReplicaConnection();
@@ -257,7 +258,7 @@ class EventRepository extends Repository
      * @return int|string[] Count of revisions, or string array with keys 'id',
      *     'timestamp', 'page', 'wiki', 'username', 'summary'.
      */
-    public function getRevisions(Event $event, $offset = 0, $limit = 50, $count = false)
+    public function getRevisions(Event $event, ?int $offset = 0, ?int $limit = 50, bool $count = false)
     {
         /** @var int TTL of cache, in seconds. */
         $cacheDuration = 300;
@@ -293,7 +294,7 @@ class EventRepository extends Repository
      * @return int|string[] Count of revisions, or string array with keys 'id',
      *     'timestamp', 'page', 'wiki', 'username', 'summary'.
      */
-    private function getRevisionsData(Event $event, $offset, $limit, $count)
+    private function getRevisionsData(Event $event, ?int $offset, ?int $limit, bool $count)
     {
         $sql = 'SELECT '.($count ? 'COUNT(id)' : '*').' FROM ('.
                 $this->getRevisionsInnerSql($event)."
@@ -326,7 +327,7 @@ class EventRepository extends Repository
      * @param Event $event
      * @return int
      */
-    public function getNumRevisions(Event $event)
+    public function getNumRevisions(Event $event): int
     {
         return $this->getRevisions($event, null, null, true);
     }
@@ -336,7 +337,7 @@ class EventRepository extends Repository
      * @param Event $event
      * @return string
      */
-    private function getRevisionsInnerSql(Event $event)
+    private function getRevisionsInnerSql(Event $event): string
     {
         if (isset($this->revisionsInnerSql)) {
             return $this->revisionsInnerSql;
@@ -388,7 +389,7 @@ class EventRepository extends Repository
      * @param Event $event
      * @return string
      */
-    private function getUsernamesSql(Event $event)
+    private function getUsernamesSql(Event $event): string
     {
         $userIds = $event->getParticipantIds();
         $usernames = array_column($this->getUsernamesFromIds($userIds), 'user_name');
@@ -406,7 +407,7 @@ class EventRepository extends Repository
      * @param Event $event
      * @return bool|null true if job has been started, false if queued, null if nonexistent.
      */
-    public function getJobStatus(Event $event)
+    public function getJobStatus(Event $event): ?bool
     {
         $conn = $this->getGrantMetricsConnection();
         $rqb = $conn->createQueryBuilder();

--- a/src/AppBundle/Repository/EventWikiRepository.php
+++ b/src/AppBundle/Repository/EventWikiRepository.php
@@ -3,6 +3,8 @@
  * This file contains only the EventWikiRepository class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Repository;
 
 use AppBundle\Model\EventWiki;
@@ -18,7 +20,7 @@ class EventWikiRepository extends Repository
      * Implements Repository::getEntityClass
      * @return string
      */
-    public function getEntityClass()
+    public function getEntityClass(): string
     {
         return EventWiki::class;
     }
@@ -28,7 +30,7 @@ class EventWikiRepository extends Repository
      * @param string $value
      * @return string|null Null if no wiki was found.
      */
-    public function getDomainFromEventWikiInput($value)
+    public function getDomainFromEventWikiInput(string $value): ?string
     {
         if (substr($value, 0, 2) === '*.') {
             $ret = $this->getWikiFamilyName(substr($value, 2));
@@ -40,8 +42,8 @@ class EventWikiRepository extends Repository
         $rqb->select(['dbname, url'])
             ->from('wiki')
             ->where($rqb->expr()->eq('dbname', ':project'))
-            ->orwhere($rqb->expr()->like('url', ':projectUrl'))
-            ->orwhere($rqb->expr()->like('url', ':projectUrl2'))
+            ->orWhere($rqb->expr()->like('url', ':projectUrl'))
+            ->orWhere($rqb->expr()->like('url', ':projectUrl2'))
             ->setParameter('project', $value)
             ->setParameter('projectUrl', "https://$value")
             ->setParameter('projectUrl2', "https://$value.org");
@@ -69,7 +71,7 @@ class EventWikiRepository extends Repository
      * @param string $value The wiki family name.
      * @return string|null The wiki family name, or null if invalid.
      */
-    public function getWikiFamilyName($value)
+    public function getWikiFamilyName(string $value): ?string
     {
         $conn = $this->getMetaConnection();
         $rqb = $conn->createQueryBuilder();
@@ -85,7 +87,7 @@ class EventWikiRepository extends Repository
      * @param EventWiki $wiki
      * @return string
      */
-    public function getDbName(EventWiki $wiki)
+    public function getDbName(EventWiki $wiki): string
     {
         $projectUrl = 'https://'.$wiki->getDomain().'.org';
 
@@ -109,7 +111,7 @@ class EventWikiRepository extends Repository
      * @return string
      * @static
      */
-    public static function wikifyString($wikitext, $domain, $pageTitle = null)
+    public static function wikifyString(string $wikitext, string $domain, $pageTitle = null): string
     {
         $wikitext = htmlspecialchars(html_entity_decode($wikitext), ENT_NOQUOTES);
         $sectionMatch = null;
@@ -138,7 +140,7 @@ class EventWikiRepository extends Repository
      * @return string Updated wikitext.
      * @static
      */
-    private static function wikifyInternalLinks($wikitext, $domain)
+    private static function wikifyInternalLinks(string $wikitext, string $domain): string
     {
         $pagePath = "https://$domain.org/wiki/";
         $linkMatch = null;
@@ -163,7 +165,7 @@ class EventWikiRepository extends Repository
      * Get all available wikis on the replicas, as defined by EventWiki::VALID_WIKI_PATTERN.
      * @return array With domain as the keys, database name as the values.
      */
-    public function getAvailableWikis()
+    public function getAvailableWikis(): array
     {
         /** @var string $validWikiRegex Regex-escaped and without surrounding forward slashes. */
         $validWikiRegex = str_replace(

--- a/src/AppBundle/Repository/OrganizerRepository.php
+++ b/src/AppBundle/Repository/OrganizerRepository.php
@@ -3,6 +3,8 @@
  * This file contains only the OrganizerRepository class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Repository;
 
 use AppBundle\Model\Organizer;
@@ -19,17 +21,17 @@ class OrganizerRepository extends Repository
      * Implements Repository::getEntityClass
      * @return string
      */
-    public function getEntityClass()
+    public function getEntityClass(): string
     {
         return Organizer::class;
     }
 
     /**
      * Fetch an Organizer by the given username.
-     * @param  string $username
+     * @param string $username
      * @return Organizer
      */
-    public function getOrganizerByUsername($username)
+    public function getOrganizerByUsername(string $username): Organizer
     {
         $userId = $this->getUserIdFromName($username);
 
@@ -55,10 +57,10 @@ class OrganizerRepository extends Repository
 
     /**
      * Get unique metrics for all Programs created by this Organizer.
-     * @param  Organizer $organizer
+     * @param Organizer $organizer
      * @return string[]
      */
-    public function getUniqueMetrics(Organizer $organizer)
+    public function getUniqueMetrics(Organizer $organizer): array
     {
         $programRepo = new ProgramRepository($this->em);
         $programRepo->setContainer($this->container);

--- a/src/AppBundle/Repository/ParticipantRepository.php
+++ b/src/AppBundle/Repository/ParticipantRepository.php
@@ -3,6 +3,8 @@
  * This file contains only the ParticipantRepository class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Repository;
 
 use AppBundle\Model\Participant;
@@ -18,18 +20,18 @@ class ParticipantRepository extends Repository
      * Implements Repository::getEntityClass
      * @return string
      */
-    public function getEntityClass()
+    public function getEntityClass(): string
     {
         return Participant::class;
     }
 
     /**
      * Fetch participant SQL rows.
-     * @param  string[] $usernames
+     * @param string[] $usernames
      * @return string[] with keys 'user_name' and 'user_id'. 'user_id' is
      *                  null if no record was found in `centralauth_p.globaluser`.
      */
-    public function getRowsFromUsernames($usernames)
+    public function getRowsFromUsernames(array $usernames): array
     {
         $userRows = $this->getUserIdsFromNames($usernames);
 

--- a/src/AppBundle/Repository/ProgramRepository.php
+++ b/src/AppBundle/Repository/ProgramRepository.php
@@ -3,6 +3,8 @@
  * This file contains only the ProgramRepository class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Repository;
 
 use AppBundle\Model\Event;
@@ -21,7 +23,7 @@ class ProgramRepository extends Repository
      * Implements Repository::getEntityClass
      * @return string
      */
-    public function getEntityClass()
+    public function getEntityClass(): string
     {
         return Program::class;
     }
@@ -33,7 +35,7 @@ class ProgramRepository extends Repository
      * @param Program $program
      * @return string[]
      */
-    public function getUniqueMetrics(Program $program)
+    public function getUniqueMetrics(Program $program): array
     {
         $rqb = $this->getGrantMetricsConnection()->createQueryBuilder();
 
@@ -71,7 +73,7 @@ class ProgramRepository extends Repository
      * @param int[] $eventIds
      * @return array With metric names as the keys.
      */
-    private function getEventWikiMetrics(QueryBuilder $rqb, array $eventIds)
+    private function getEventWikiMetrics(QueryBuilder $rqb, array $eventIds): array
     {
         $eventWikiIds = $rqb->select(['DISTINCT(ew_id)'])
             ->from('event_wiki')
@@ -94,7 +96,7 @@ class ProgramRepository extends Repository
      * @param Program $program
      * @return int
      */
-    public function getNumParticipants(Program $program)
+    public function getNumParticipants(Program $program): int
     {
         $rqb = $this->getGrantMetricsConnection()->createQueryBuilder();
 
@@ -105,7 +107,7 @@ class ProgramRepository extends Repository
             return 0;
         }
 
-        return $rqb->select(['COUNT(DISTINCT(par_user_id))'])
+        return (int)$rqb->select(['COUNT(DISTINCT(par_user_id))'])
             ->from('participant')
             ->where('par_event_id IN (:eventIds)')
             ->setParameter('eventIds', $eventIds, Connection::PARAM_INT_ARRAY)

--- a/src/AppBundle/Service/JobHandler.php
+++ b/src/AppBundle/Service/JobHandler.php
@@ -3,6 +3,8 @@
  * This file contains only the JobHandler class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Service;
 
 use AppBundle\Model\Job;
@@ -54,14 +56,12 @@ class JobHandler
     }
 
     /**
-     * Query the job queue and spawn Jobs, attempting no more than what
-     * is permitted with our quota.
-     * @param OutputInterface &$output Used by Commands so that the output
-     *   can be controlled by the parent process. If this is null,
-     *   a local LoggerInterface is used instead.
+     * Query the job queue and spawn Jobs, attempting no more than what is permitted with our quota.
+     * @param OutputInterface &$output Used by Commands so that the output can be controlled by the parent process.
+     *   If this is null, a local LoggerInterface is used instead.
      * @return int The number of jobs processed.
      */
-    public function spawnAll(OutputInterface &$output = null)
+    public function spawnAll(OutputInterface &$output = null): int
     {
         $this->output = $output;
 
@@ -72,7 +72,7 @@ class JobHandler
          */
         if ($this->getQuota() === 0) {
             $this->log(
-                "<error>Not enough datbase quota to run any jobs. Please try again later.</error>"
+                "<error>Not enough database quota to run any jobs. Please try again later.</error>"
             );
         }
         // @codeCoverageIgnoreEnd
@@ -127,7 +127,7 @@ class JobHandler
      * @return array|null Generated stats, or null if queued or failed.
      * @codeCoverageIgnore
      */
-    private function processJob(Job $job)
+    private function processJob(Job $job): ?array
     {
         // Flag the job as started. This must be flushed to the database
         // immediately to avoid conflicts with the cron job, and to ensure
@@ -145,7 +145,7 @@ class JobHandler
      * self::DATABASE_QUOTA and the current number of open connections.
      * @return Job[]
      */
-    private function getQueuedJobs()
+    private function getQueuedJobs(): array
     {
         /** @var int Number of jobs to fire. This shouldn't be a negative number :) */
         $limit = $this->getQuota();
@@ -156,11 +156,10 @@ class JobHandler
     }
 
     /**
-     * Get the number of jobs we can run concurrently, based on
-     * how many queries are already running and our quota.
+     * Get the number of jobs we can run concurrently, based on how many queries are already running and our quota.
      * @return int
      */
-    private function getQuota()
+    private function getQuota(): int
     {
         return max([self::DATABASE_QUOTA - $this->getNumOpenConnections(), 0]);
     }
@@ -169,7 +168,7 @@ class JobHandler
      * Get the number of open connections to the replicas database.
      * @return int
      */
-    private function getNumOpenConnections()
+    private function getNumOpenConnections(): int
     {
         $conn = $this->container
             ->get('doctrine')
@@ -190,7 +189,7 @@ class JobHandler
      * be tested, but the output via $this->output does have test coverage.
      * @codeCoverageIgnore
      */
-    private function log($message)
+    private function log($message): void
     {
         if ($this->output === null) {
             $this->logger->info($message);

--- a/src/AppBundle/Twig/ControllerActionExtension.php
+++ b/src/AppBundle/Twig/ControllerActionExtension.php
@@ -3,6 +3,8 @@
  * This file contains only the ControllerActionExtension class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Twig;
 
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -30,7 +32,7 @@ class ControllerActionExtension extends Twig_Extension
      * Get the name of this extension.
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return 'controller_action_twig_extension';
     }
@@ -39,7 +41,7 @@ class ControllerActionExtension extends Twig_Extension
      * Get all functions that this class provides.
      * @return array
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new \Twig_SimpleFunction('getControllerName', [$this, 'getControllerName']),
@@ -53,7 +55,7 @@ class ControllerActionExtension extends Twig_Extension
      * There is no request stack in unit tests.
      * @codeCoverageIgnore
      */
-    public function getControllerName()
+    public function getControllerName(): string
     {
         $request = $this->requestStack->getCurrentRequest();
 
@@ -72,7 +74,7 @@ class ControllerActionExtension extends Twig_Extension
      * There is no request stack in unit tests.
      * @codeCoverageIgnore
      */
-    public function getActionName()
+    public function getActionName(): string
     {
         $request = $this->requestStack->getCurrentRequest();
 

--- a/src/AppBundle/Twig/Extension.php
+++ b/src/AppBundle/Twig/Extension.php
@@ -3,6 +3,8 @@
  * This file contains only the Extension class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Twig;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -55,7 +57,7 @@ abstract class Extension extends Twig_Extension
      * @return Intuition
      * @throws \Exception If the 'i18n/en.json' file doesn't exist (as it's the default).
      */
-    protected function getIntuition()
+    protected function getIntuition(): Intuition
     {
         return $this->intuition;
     }
@@ -66,28 +68,9 @@ abstract class Extension extends Twig_Extension
      * There is no request stack in the tests.
      * @codeCoverageIgnore
      */
-    protected function getCurrentRequest()
+    protected function getCurrentRequest(): Request
     {
         return $this->container->get('request_stack')->getCurrentRequest();
-    }
-
-    /**
-     * Determine the interface language, either from the current request or session.
-     * @return string
-     */
-    private function getIntuitionLang()
-    {
-        $queryLang = $this->requestStack->getCurrentRequest()->query->get('uselang');
-        $sessionLang = $this->session->get('lang');
-
-        if (!empty($queryLang)) {
-            return $queryLang;
-        } elseif (!empty($sessionLang)) {
-            return $sessionLang;
-        }
-
-        // English as default.
-        return 'en';
     }
 
     /**

--- a/src/AppBundle/Twig/FormatExtension.php
+++ b/src/AppBundle/Twig/FormatExtension.php
@@ -3,6 +3,8 @@
  * This file contains only the FormatExtension class.
  */
 
+declare(strict_types=1);
+
 namespace AppBundle\Twig;
 
 use AppBundle\Repository\EventWikiRepository;
@@ -26,7 +28,7 @@ class FormatExtension extends Extension
      * Get the name of this extension.
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return 'format_extension';
     }
@@ -37,7 +39,7 @@ class FormatExtension extends Extension
      * Get all functions that this class provides.
      * @return array
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new \Twig_SimpleFunction('formatDuration', [$this, 'formatDuration']),
@@ -51,7 +53,7 @@ class FormatExtension extends Extension
      * Get all filters for this extension.
      * @return array
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new \Twig_SimpleFilter('ucfirst', [$this, 'ucfirst']),
@@ -66,11 +68,11 @@ class FormatExtension extends Extension
 
     /**
      * Format a number based on language settings.
-     * @param  int|float $number
-     * @param  int $decimals Number of decimals to format to.
+     * @param int|float $number
+     * @param int $decimals Number of decimals to format to.
      * @return string
      */
-    public function numberFormat($number, $decimals = 0)
+    public function numberFormat($number, int $decimals = 0): string
     {
         if (!isset($this->numFormatter)) {
             $lang = $this->getIntuition()->getLang();
@@ -89,10 +91,10 @@ class FormatExtension extends Extension
 
     /**
      * Localize the given date based on language settings.
-     * @param  string|DateTime $datetime
+     * @param string|DateTime $datetime
      * @return string
      */
-    public function dateFormat($datetime)
+    public function dateFormat($datetime): string
     {
         // If the language is 'en' with no country code,
         // override the US English format that's provided by ICU.
@@ -118,10 +120,10 @@ class FormatExtension extends Extension
 
     /**
      * Format the given date to ISO 8601.
-     * @param  string|DateTime $datetime
+     * @param string|DateTime $datetime
      * @return string
      */
-    public function dateFormatStd($datetime)
+    public function dateFormatStd($datetime): string
     {
         if (is_string($datetime) || is_int($datetime)) {
             $datetime = new DateTime($datetime);
@@ -133,22 +135,22 @@ class FormatExtension extends Extension
     /**
      * Mysteriously missing Twig helper to capitalize only the first character.
      * E.g. used for table headings for translated messages.
-     * @param  string $str The string
-     * @return string      The string, capitalized
+     * @param string $str The string
+     * @return string The string, capitalized
      */
-    public function ucfirst($str)
+    public function ucfirst($str): string
     {
         return ucfirst($str);
     }
 
     /**
      * Format a given number or fraction as a percentage.
-     * @param  number  $numerator   Numerator or single fraction if denominator is ommitted.
-     * @param  number  $denominator Denominator.
-     * @param  integer $precision   Number of decimal places to show.
-     * @return string               Formatted percentage.
+     * @param int|float $numerator Numerator or single fraction if denominator is omitted.
+     * @param int|float $denominator Denominator.
+     * @param int $precision Number of decimal places to show.
+     * @return string Formatted percentage.
      */
-    public function percentFormat($numerator, $denominator = null, $precision = 1)
+    public function percentFormat($numerator, $denominator = null, int $precision = 1)
     {
         if (!$denominator) {
             $quotient = $numerator;
@@ -160,11 +162,11 @@ class FormatExtension extends Extension
     }
 
     /**
-     * Format a given number as a diff, colouring it green if it's postive, red if negative, gary if zero
-     * @param  number $size Diff size
-     * @return string       Markup with formatted number
+     * Format a given number as a diff, colouring it green if it's positive, red if negative, gary if zero.
+     * @param int $size Diff size
+     * @return string Markup with formatted number
      */
-    public function diffFormat($size)
+    public function diffFormat(int $size): string
     {
         if ($size < 0) {
             $class = 'diff-neg';
@@ -187,7 +189,7 @@ class FormatExtension extends Extension
      * @return string|array Examples: '30 seconds', '2 minutes', '15 hours', '500 days',
      *   or [30, 'num-seconds'] (etc.) if $translate is false.
      */
-    public function formatDuration($seconds, $translate = true)
+    public function formatDuration(int $seconds, bool $translate = true)
     {
         list($val, $key) = $this->getDurationMessageKey($seconds);
 
@@ -200,10 +202,10 @@ class FormatExtension extends Extension
 
     /**
      * Given a time duration in seconds, generate a i18n message key and value.
-     * @param  int $seconds Number of seconds.
+     * @param int $seconds Number of seconds.
      * @return array [int - message value, string - message key]
      */
-    private function getDurationMessageKey($seconds)
+    private function getDurationMessageKey(int $seconds): array
     {
         /** @var int Value to show in message */
         $val = $seconds;
@@ -235,7 +237,7 @@ class FormatExtension extends Extension
      * @param string $pageTitle Page title including namespace.
      * @return string
      */
-    public function wikify($wikitext, $domain, $pageTitle = null)
+    public function wikify(string $wikitext, string $domain, ?string $pageTitle = null): string
     {
         return EventWikiRepository::wikifyString($wikitext, $domain, $pageTitle);
     }


### PR DESCRIPTION
This takes advantage of PHP 7.2 scalar type hints and return types.
Some things will likely break, but those things are likely bugs
which is why I think doing this is a good idea.

See https://symfonycasts.com/screencast/php7/scalar-type-hints for more.

Other various cleanup.