### PR TITLE
Store category IDs as well as titles, add subscriber to set the ID

### DIFF
--- a/app/DoctrineMigrations/Version20180921215535.php
+++ b/app/DoctrineMigrations/Version20180921215535.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20180921215535 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX ec_event_domains ON event_category');
+        $this->addSql('ALTER TABLE event_category ADD ec_category_id INT NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX ec_event_domains ON event_category (ec_event_id, ec_category_id, ec_domain)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX ec_event_domains ON event_category');
+        $this->addSql('ALTER TABLE event_category DROP ec_category_id');
+        $this->addSql('CREATE UNIQUE INDEX ec_event_domains ON event_category (ec_event_id, ec_title, ec_domain)');
+    }
+}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -39,6 +39,10 @@ services:
         tags:
             - { name: doctrine.orm.entity_listener }
 
+    AppBundle\EventSubscriber\CategorySubscriber:
+        tags:
+            - { name: doctrine.orm.entity_listener }
+
     AppBundle\EventSubscriber\ProgramSubscriber:
         tags:
             - { name: doctrine.orm.entity_listener }

--- a/src/AppBundle/EventSubscriber/CategorySubscriber.php
+++ b/src/AppBundle/EventSubscriber/CategorySubscriber.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This file contains only the CategorySubscriber class.
+ */
+
+declare(strict_types=1);
+
+namespace AppBundle\EventSubscriber;
+
+use AppBundle\Model\EventCategory;
+use AppBundle\Repository\EventCategoryRepository;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Psr\Container\ContainerInterface;
+
+/**
+ * CategorySubscriber automatically sets the category ID on EventCategories before they are persisted.
+ * This isn't usually needed because categories are (currently) only created through the HTML form, which has it's own
+ * validation for category ID. This is here for when categories are persisted by other means.
+ */
+class CategorySubscriber
+{
+    /** @var ContainerInterface The application's container interface. */
+    private $container;
+
+    /**
+     * Constructor for CategorySubscriber.
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Set the category ID on the EventCategory upon persisting.
+     * @param EventCategory $category
+     * @param LifecycleEventArgs $event Doctrine lifecycle event arguments.
+     */
+    public function prePersist(EventCategory $category, LifecycleEventArgs $event): void
+    {
+        if (null !== $category->getCategoryId()) {
+            return;
+        }
+
+        /** @var EntityManager $em */
+        $em = $event->getEntityManager();
+
+        /** @var EventCategoryRepository $ecRepo */
+        $ecRepo = $em->getRepository(EventCategory::class);
+        $ecRepo->setContainer($this->container);
+
+        $catId = $ecRepo->getCategoryId($category->getDomain(), $category->getTitle(true));
+
+        if (is_int($catId)) {
+            $category->setCategoryId($catId);
+        }
+    }
+}

--- a/src/AppBundle/Service/EventProcessor.php
+++ b/src/AppBundle/Service/EventProcessor.php
@@ -273,7 +273,7 @@ class EventProcessor
             $this->event->getStartWithTimezone(),
             $this->event->getEndWithTimezone(),
             $this->getParticipantNames(),
-            $this->event->getCategoryTitlesForWiki($wiki)
+            $this->event->getCategoryIdsForWiki($wiki)
         );
         $pagesCreated += $ret['created'];
         $pagesImproved += $ret['edited'];
@@ -320,7 +320,7 @@ class EventProcessor
             $this->event->getStartWithTimezone(),
             $this->event->getEndWithTimezone(),
             $this->getParticipantNames(),
-            $this->event->getCategoryTitlesForWiki($wiki)
+            $this->event->getCategoryIdsForWiki($wiki)
         );
         // Report the counts, and record them both for this wiki and the event (there's only ever one Wikidata wiki).
         $this->log(">> <info>Items created: {$ret['created']}</info>");

--- a/tests/AppBundle/Controller/EventControllerTest.php
+++ b/tests/AppBundle/Controller/EventControllerTest.php
@@ -59,6 +59,7 @@ class EventControllerTest extends DatabaseAwareWebTestCase
         $this->familyWikiSpec();
         $this->showSpec();
         $this->participantsSpec();
+        $this->categoriesSpec();
         $this->cloneSpec();
         $this->deleteSpec();
     }
@@ -354,6 +355,63 @@ class EventControllerTest extends DatabaseAwareWebTestCase
     }
 
     /**
+     * Add/remove categories to the Event.
+     */
+    public function categoriesSpec(): void
+    {
+        $this->markTestSkipped(
+            'Until the categories frontend is enabled.'
+        );
+//        // Browse to event page.
+//        $this->crawler = $this->client->request('GET', '/programs/My_fun_program/Pinocchio');
+//        $this->response = $this->client->getResponse();
+//
+//        $form = $this->crawler->selectButton('Save categories')->form();
+//
+//        // Should have an empty row.
+//        static::assertEquals('', $form['categoryForm[categories][0][title]']->getValue());
+//
+//        // Start with an invalid category title.
+//        $form['categoryForm[categories][0][title]'] = 'Invalid category 12345';
+//        $this->crawler = $this->client->submit($form);
+//        static::assertContains(
+//            '1 category is invalid',
+//            $this->crawler->filter('.alert-danger')->text()
+//        );
+//        static::assertContains(
+//            'has-error',
+//            $this->crawler->filter('#categoryForm_categories_0_title')->parents()->attr('class')
+//        );
+//
+//        // Invalid wiki.
+//        $form['categoryForm[categories][0][title]'] = 'Parks in Brooklyn';
+//        $form['categoryForm[categories][0][domain]'] = 'invalid.wikipedia.org';
+//        $this->crawler = $this->client->submit($form);
+//        static::assertContains(
+//            '1 category is invalid',
+//            $this->crawler->filter('.alert-danger')->text()
+//        );
+//
+//        // Add a valid category and wiki (category is already set from above).
+//        $form['categoryForm[categories][0][domain]'] = 'en.wikipedia.org';
+//        $this->crawler = $this->client->submit($form);
+//        $this->response = $this->client->getResponse();
+//        static::assertEquals(302, $this->response->getStatusCode());
+//
+//        // Make sure it was saved to the database.
+//        $eventRepo = $this->entityManager->getRepository('Model:Event');
+//        $event = $eventRepo->findOneBy(['title' => 'Pinocchio']);
+//        $this->entityManager->refresh($event); // Clear cache, unclear why this is needed.
+//        static::assertEquals('Parks in Brooklyn', $event->getCategories()->first()->getTitle());
+//
+//        // One last pass to make sure the category is listed.
+//        static::assertEquals(
+//            'Parks in Brooklyn',
+//            $form->get('categoryForm[categories][0][title]')->getValue()
+//        );
+    }
+
+    /**
      * Cloning an Event.
      */
     private function cloneSpec(): void
@@ -391,6 +449,8 @@ class EventControllerTest extends DatabaseAwareWebTestCase
             [10584730],
             $event->getParticipantIds()
         );
+
+        static::assertEquals('Parks in Brooklyn', $event->getCategories()->first()->getTitle());
     }
 
     /**

--- a/tests/AppBundle/Model/EventCategoryTest.php
+++ b/tests/AppBundle/Model/EventCategoryTest.php
@@ -48,8 +48,7 @@ class EventCategoryTest extends GrantMetricsTestCase
 
         // Getters.
         static::assertEquals($this->event, $eventCategory->getEvent());
-        static::assertEquals('Foo_bar', $eventCategory->getTitle());
-        static::assertEquals('Foo bar', $eventCategory->getDisplayTitle());
+        static::assertEquals('Foo bar', $eventCategory->getTitle());
     }
 
     /**


### PR DESCRIPTION
Remove invalid categories upon saving Event

Rework EventWikiRepository::getDbName to go off of a domain and not an EventWiki object, since
EventCategory is not tied to an EventWiki.

Bug: https://phabricator.wikimedia.org/T194707