### PR TITLE
Add 'bdi' Twig function, and use it for user-generated text

### DIFF
--- a/app/Resources/views/events/edit.html.twig
+++ b/app/Resources/views/events/edit.html.twig
@@ -4,9 +4,9 @@
 {% block breadcrumb %}
     <ol class="breadcrumb">
         <li>
-            <a href="{{ path('Program', {'programTitle': event.program.title}) }}">{{ event.program.displayTitle }}</a>
+            <a href="{{ path('Program', {'programTitle': event.program.title}) }}">{{ bdi(event.program.displayTitle) }}</a>
         </li>
-        <li class="active">{{ event.displayTitle }}</li>
+        <li class="active">{{ bdi(event.displayTitle) }}</li>
     </ol>
 {% endblock %}
 

--- a/app/Resources/views/events/new.html.twig
+++ b/app/Resources/views/events/new.html.twig
@@ -7,7 +7,7 @@
             <a href="{{ path('Programs') }}">{{ msg('my-programs') }}</a>
         </li>
         <li>
-            <a href="{{ path('Program', {'programTitle': event.program.title}) }}">{{ event.program.displayTitle }}</a>
+            <a href="{{ path('Program', {'programTitle': event.program.title}) }}">{{ bdi(event.program.displayTitle) }}</a>
         </li>
         <li class="active">
             {{ msg('create-new-event') }}

--- a/app/Resources/views/events/revisions.html.twig
+++ b/app/Resources/views/events/revisions.html.twig
@@ -10,10 +10,10 @@
             </li>
         {% endif %}
         <li>
-            <a href="{{ path('Program', {'programTitle': program.title}) }}">{{ program.displayTitle }}</a>
+            <a href="{{ path('Program', {'programTitle': program.title}) }}">{{ bdi(program.displayTitle) }}</a>
         </li>
         <li>
-            <a href="{{ path('Event', {'programTitle': program.title, 'eventTitle': event.title}) }}">{{ event.displayTitle }}</a>
+            <a href="{{ path('Event', {'programTitle': program.title, 'eventTitle': event.title}) }}">{{ bdi(event.displayTitle) }}</a>
         </li>
         <li class="active">{{ msg('event-data') }}</li>
     </ol>

--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -9,10 +9,10 @@
             </li>
         {% endif %}
         <li>
-            <a href="{{ path('Program', {'programTitle': program.title}) }}">{{ program.displayTitle }}</a>
+            <a href="{{ path('Program', {'programTitle': program.title}) }}">{{ bdi(program.displayTitle) }}</a>
         </li>
         <li class="active">
-            {{ event.displayTitle }}
+            {{ bdi(event.displayTitle) }}
         </li>
     </ol>
 {% endblock %}
@@ -21,7 +21,7 @@
     <div class="container">
         <div class="page-header">
             <h1>
-                {{ event.displayTitle }}
+                {{ bdi(event.displayTitle) }}</bdi>
                 {% if isOrganizer %}
                     <small>
                         (<a href="{{ path('EditEvent', {'programTitle': program.title, 'eventTitle': event.title}) }}">{{ msg('edit-event')|lower }}</a>)

--- a/app/Resources/views/programs/edit.html.twig
+++ b/app/Resources/views/programs/edit.html.twig
@@ -6,7 +6,7 @@
         <li>
             <a href="{{ path('Programs') }}">{{ msg('my-programs') }}</a>
         </li>
-        <li class="active">{{ program.displayTitle }}</li>
+        <li class="active">{{ bdi(program.displayTitle) }}</li>
     </ol>
 {% endblock %}
 

--- a/app/Resources/views/programs/index.html.twig
+++ b/app/Resources/views/programs/index.html.twig
@@ -51,7 +51,7 @@
                     {% for program in programs %}
                         <tr class="program-entry">
                             <td class="sort-entry--program" data-value="{{ program.title }}">
-                                <a href="{{ path('Program', {'programTitle': program.title}) }}">{{ program.displayTitle }}</a>
+                                <a href="{{ path('Program', {'programTitle': program.title}) }}">{{ bdi(program.displayTitle) }}</a>
                             </td>
                             <td>
                                 {{ layout.actionButtons('Program', program, {'programTitle': program.title}, program.numEvents == 0) }}

--- a/app/Resources/views/programs/show.html.twig
+++ b/app/Resources/views/programs/show.html.twig
@@ -8,7 +8,7 @@
                 <a href="{{ path('Programs') }}">{{ msg('my-programs') }}</a>
             </li>
         {% endif %}
-        <li class="active">{{ program.displayTitle }}</li>
+        <li class="active">{{ bdi(program.displayTitle) }}</li>
     </ol>
 {% endblock %}
 
@@ -21,7 +21,7 @@
                 </a>
             {% endif %}
             <h1>
-                {{ program.displayTitle }}
+                {{ bdi(program.displayTitle) }}
                 {% if isOrganizer %}
                     <small>
                         (<a href="{{ path('EditProgram', {'programTitle': program.title}) }}">{{ msg('edit-program')|lower }}</a>)

--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -47,6 +47,7 @@ class AppExtension extends Extension
             new \Twig_SimpleFunction('shortHash', [$this, 'gitShortHash']),
             new \Twig_SimpleFunction('hash', [$this, 'gitHash']),
             new \Twig_SimpleFunction('wikiPath', [$this, 'wikiPath']),
+            new \Twig_SimpleFunction('bdi', [$this, 'bdi'], $options),
         ];
     }
 

--- a/src/AppBundle/Twig/Extension.php
+++ b/src/AppBundle/Twig/Extension.php
@@ -61,4 +61,13 @@ abstract class Extension extends Twig_Extension
     {
         return $this->container->get('request_stack')->getCurrentRequest();
     }
+	/**
+	 * Wrap a text with <bdi> tags for BiDirectional isolation
+	 * @param string $text Given text
+	 * @return string The given text, wrapped with <bdi> tags
+	 */
+	public function bdi($text = '')
+	{
+		return '<bdi>'.$text.'</bdi>';
+	}
 }

--- a/tests/AppBundle/Twig/AppExtensionTest.php
+++ b/tests/AppBundle/Twig/AppExtensionTest.php
@@ -45,4 +45,12 @@ class AppExtensionTest extends GrantMetricsTestCase
         static::assertEquals(7, strlen($this->appExtension->gitShortHash()));
         static::assertEquals(40, strlen($this->appExtension->gitHash()));
     }
+
+    /**
+     * Test bdi function
+     */
+    public function testBDI()
+    {
+        static::assertEquals('<bdi>Foo</bdi>', $this->appExtension->bdi('Foo'));
+    }
 }


### PR DESCRIPTION
Wrap all user-generated content in bdi tags, so that directionality
is preserved even when read through other interface languages.

More specifically, event and program names in Farsi, Arabic or
Hebrew (RTL) will be desplayed correctly even if the user
viewing them in English (LTR)

See Phabricator task: https://phabricator.wikimedia.org/T205172