### PR TITLE
Kill stale jobs when viewing event page / revision browser

### DIFF
--- a/src/AppBundle/Controller/EventDataController.php
+++ b/src/AppBundle/Controller/EventDataController.php
@@ -32,10 +32,18 @@ class EventDataController extends EntityController
      * @Route("/programs/{programTitle}/{eventTitle}/revisions", name="Revisions")
      * @Route("/programs/{programTitle}/{eventTitle}/revisions/", name="RevisionsSlash")
      * @param EventRepository $eventRepo
+     * @param JobHandler $jobHandler
      * @return Response
      */
-    public function revisionsAction(EventRepository $eventRepo): Response
+    public function revisionsAction(EventRepository $eventRepo, JobHandler $jobHandler): Response
     {
+        /**
+         * Kill any old, stale jobs. This would normally be handled via cron but it is not trivial to add a cronjob
+         * within a Toolforge kubernetes container.
+         * @see https://phabricator.wikimedia.org/T192954
+         */
+        $jobHandler->handleStaleJobs($this->event);
+
         // Redirect to event page if statistics have not yet been generated.
         if (null === $this->event->getUpdated()) {
             return $this->redirectToRoute('Event', [

--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -770,10 +770,31 @@ class Event
     }
 
     /**
+     * Remove a Job from the Event. This does NOT kill the job if it is currently running.
+     * @param Job $job
+     */
+    public function removeJob(Job $job): void
+    {
+        $this->jobs->remove($job);
+    }
+
+    /**
      * Remove all Jobs from this Event.
      */
-    public function removeJobs(): void
+    public function clearJobs(): void
     {
         $this->jobs->clear();
+    }
+
+    /**
+     * Get stale jobs that have been idling for a long time (specified by $offset).
+     * @param string $offset String accepted by DateTime constructor.
+     * @return Collection
+     */
+    public function getStaleJobs(string $offset = '-1 hour'): Collection
+    {
+        return $this->jobs->filter(function (Job $job) use ($offset) {
+            return $job->getSubmitted() <= new DateTime($offset);
+        });
     }
 }

--- a/src/AppBundle/Service/EventProcessor.php
+++ b/src/AppBundle/Service/EventProcessor.php
@@ -95,7 +95,7 @@ class EventProcessor
         $this->setRetention();
 
         // Clear out any existing job records from the queue.
-        $event->removeJobs();
+        $event->clearJobs();
 
         // Update the 'updated' attribute.
         $event->setUpdated(new DateTime());

--- a/tests/AppBundle/Model/EventTest.php
+++ b/tests/AppBundle/Model/EventTest.php
@@ -277,7 +277,15 @@ class EventTest extends GrantMetricsTestCase
         static::assertTrue($event->hasJob());
         static::assertEquals(1, $event->getNumJobs());
         static::assertEquals($job, $event->getJobs()[0]);
-        $event->removeJobs();
+
+        // Set the submitted timestamp, normally called when persisting the Job.
+        $job->setSubmitted();
+        // The Job hence should not be 'stale' because we just created it.
+        static::assertNotContains($job, $event->getStaleJobs());
+        // The Job is stale if we use an offset of 0 seconds.
+        static::assertContains($job, $event->getStaleJobs('-0 seconds'));
+
+        $event->clearJobs();
         static::assertFalse($event->hasJob());
         static::assertEquals(0, $event->getNumJobs());
     }


### PR DESCRIPTION
This is a cheap way around our inability to have cronjobs within the
php7.2 container on Toolforge. Ideally we'd *start* old unstarted jobs
by calling JobHandler::spawnAll(), but we can't do this from a web
request without generating all the stats, meaning the user will have
to wait before the page even loads.

Bug: https://phabricator.wikimedia.org/T192954