### PR TITLE
Add 'bdi' Twig function, and use it for user-generated text

### DIFF
--- a/app/Resources/views/events/edit.html.twig
+++ b/app/Resources/views/events/edit.html.twig
@@ -4,9 +4,9 @@
 {% block breadcrumb %}
     <ol class="breadcrumb">
         <li>
-            <a href="{{ path('Program', {'programId': event.program.id}) }}">{{ event.program.displayTitle }}</a>
+            <a href="{{ path('Program', {'programId': event.program.id}) }}">{{ bdi(event.program.displayTitle) }}</a>
         </li>
-        <li class="active">{{ event.displayTitle }}</li>
+        <li class="active">{{ bdi(event.displayTitle) }}</li>
     </ol>
 {% endblock %}
 

--- a/app/Resources/views/events/new.html.twig
+++ b/app/Resources/views/events/new.html.twig
@@ -7,7 +7,7 @@
             <a href="{{ path('Programs') }}">{{ msg('my-programs') }}</a>
         </li>
         <li>
-            <a href="{{ path('Program', {'programId': event.program.id}) }}">{{ event.program.displayTitle }}</a>
+            <a href="{{ path('Program', {'programId': event.program.id}) }}">{{ bdi(event.program.displayTitle) }}</a>
         </li>
         <li class="active">
             {{ msg('create-new-event') }}

--- a/app/Resources/views/events/revisions.html.twig
+++ b/app/Resources/views/events/revisions.html.twig
@@ -10,10 +10,10 @@
             </li>
         {% endif %}
         <li>
-            <a href="{{ path('Program', {'programId': program.id}) }}">{{ program.displayTitle }}</a>
+            <a href="{{ path('Program', {'programId': program.id}) }}">{{ bdi(program.displayTitle) }}</a>
         </li>
         <li>
-            <a href="{{ path('Event', {'programId': program.id, 'eventId': event.id}) }}">{{ event.displayTitle }}</a>
+            <a href="{{ path('Event', {'programId': program.id, 'eventId': event.id}) }}">{{ bdi(event.displayTitle) }}</a>
         </li>
         <li class="active">{{ msg('event-data') }}</li>
     </ol>

--- a/app/Resources/views/events/show.html.twig
+++ b/app/Resources/views/events/show.html.twig
@@ -9,10 +9,10 @@
             </li>
         {% endif %}
         <li>
-            <a href="{{ path('Program', {'programId': program.id}) }}">{{ program.displayTitle }}</a>
+            <a href="{{ path('Program', {'programId': program.id}) }}">{{ bdi(program.displayTitle) }}</a>
         </li>
         <li class="active">
-            {{ event.displayTitle }}
+            {{ bdi(event.displayTitle) }}
         </li>
     </ol>
 {% endblock %}
@@ -21,7 +21,7 @@
     <div class="container">
         <div class="page-header">
             <h1>
-                {{ event.displayTitle }}
+                {{ bdi(event.displayTitle) }}
                 {% if isOrganizer %}
                     <small>
                         (<a href="{{ path('EditEvent', {'programId': program.id, 'eventId': event.id}) }}">{{ msg('edit-event')|lower }}</a>)

--- a/app/Resources/views/programs/edit.html.twig
+++ b/app/Resources/views/programs/edit.html.twig
@@ -6,7 +6,7 @@
         <li>
             <a href="{{ path('Programs') }}">{{ msg('my-programs') }}</a>
         </li>
-        <li class="active">{{ program.displayTitle }}</li>
+        <li class="active">{{ bdi(program.displayTitle) }}</li>
     </ol>
 {% endblock %}
 

--- a/app/Resources/views/programs/index.html.twig
+++ b/app/Resources/views/programs/index.html.twig
@@ -51,7 +51,7 @@
                     {% for program in programs %}
                         <tr class="program-entry">
                             <td class="sort-entry--program" data-value="{{ program.title }}">
-                                <a href="{{ path('Program', {'programId': program.id}) }}">{{ program.displayTitle }}</a>
+                                <a href="{{ path('Program', {'programId': program.id}) }}">{{ bdi(program.displayTitle) }}</a>
                             </td>
                             <td>
                                 {{ layout.actionButtons('Program', program, {'programId': program.id}, program.numEvents == 0) }}

--- a/app/Resources/views/programs/show.html.twig
+++ b/app/Resources/views/programs/show.html.twig
@@ -8,7 +8,7 @@
                 <a href="{{ path('Programs') }}">{{ msg('my-programs') }}</a>
             </li>
         {% endif %}
-        <li class="active">{{ program.displayTitle }}</li>
+        <li class="active">{{ bdi(program.displayTitle) }}</li>
     </ol>
 {% endblock %}
 
@@ -21,7 +21,7 @@
                 </a>
             {% endif %}
             <h1>
-                {{ program.displayTitle }}
+                {{ bdi(program.displayTitle) }}
                 {% if isOrganizer %}
                     <small>
                         (<a href="{{ path('EditProgram', {'programId': program.id}) }}">{{ msg('edit-program')|lower }}</a>)
@@ -68,7 +68,7 @@
                     {% for event in program.events %}
                         <tr class="event-entry">
                             <td class="sort-entry--event" data-value="{{ event.title }}">
-                                <a href="{{ path('Event', {'programId': program.id, 'eventId': event.id}) }}">{{ event.displayTitle }}</a>
+                                <a href="{{ path('Event', {'programId': program.id, 'eventId': event.id}) }}">{{ bdi(event.displayTitle) }}</a>
                             </td>
                             {% set numParticipants = event.numParticipants %}
                             {% if isOrganizer %}

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/symfony": "^4.0",
         "symfony/webpack-encore-pack": "^1.0",
         "twig/twig": "^2.0",
-        "wikimedia/toolforge-bundle": "^0.5"
+        "wikimedia/toolforge-bundle": "^0.7"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ba143206d76234e4398db8cdbfa30b3",
+    "content-hash": "461847eb20919ad5d567c21e4ed59dd6",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -2998,16 +2998,16 @@
         },
         {
             "name": "wikimedia/toolforge-bundle",
-            "version": "0.5.0",
+            "version": "0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikimedia/ToolforgeBundle.git",
-                "reference": "09eeea26415572358637d7b887a5cf76507d2fd1"
+                "reference": "51aa306d00e9c6deae152a535ef12ada34fd592b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/ToolforgeBundle/zipball/09eeea26415572358637d7b887a5cf76507d2fd1",
-                "reference": "09eeea26415572358637d7b887a5cf76507d2fd1",
+                "url": "https://api.github.com/repos/wikimedia/ToolforgeBundle/zipball/51aa306d00e9c6deae152a535ef12ada34fd592b",
+                "reference": "51aa306d00e9c6deae152a535ef12ada34fd592b",
                 "shasum": ""
             },
             "require": {
@@ -3019,7 +3019,7 @@
                 "symfony/twig-bridge": "^4.1"
             },
             "require-dev": {
-                "squizlabs/php_codesniffer": "^3.3",
+                "slevomat/coding-standard": "^4.8",
                 "symfony/phpunit-bridge": "^4.1"
             },
             "type": "symfony-bundle",
@@ -3040,7 +3040,7 @@
             ],
             "description": "Symfony 4 bundle providing useful Toolforge features.",
             "homepage": "https://github.com/wikimedia/toolforgebundle",
-            "time": "2018-09-26T01:48:58+00:00"
+            "time": "2018-10-06T01:32:43+00:00"
         },
         {
             "name": "zendframework/zend-code",


### PR DESCRIPTION
Wrap all user-generated content in bdi tags, so that directionality
is preserved even when read through other interface languages.

More specifically, event and program names in Farsi, Arabic or
Hebrew (RTL) will be desplayed correctly even if the user
viewing them in English (LTR)

**
Depends on merging the pull request on ToolforgeBundle first. 
https://github.com/wikimedia/ToolforgeBundle/pull/6
**

See Phabricator task: https://phabricator.wikimedia.org/T205172