### PR TITLE
Improve performance of querying for revs within categories

### DIFF
--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -775,7 +775,10 @@ class Event
      */
     public function removeJob(Job $job): void
     {
-        $this->jobs->remove($job);
+        if (!$this->jobs->contains($job)) {
+            return;
+        }
+        $this->jobs->removeElement($job);
     }
 
     /**

--- a/src/AppBundle/Service/EventProcessor.php
+++ b/src/AppBundle/Service/EventProcessor.php
@@ -273,7 +273,7 @@ class EventProcessor
             $this->event->getStartWithTimezone(),
             $this->event->getEndWithTimezone(),
             $this->getParticipantNames(),
-            $this->event->getCategoryIdsForWiki($wiki)
+            $this->event->getCategoryTitlesForWiki($wiki)
         );
         $pagesCreated += $ret['created'];
         $pagesImproved += $ret['edited'];
@@ -320,7 +320,7 @@ class EventProcessor
             $this->event->getStartWithTimezone(),
             $this->event->getEndWithTimezone(),
             $this->getParticipantNames(),
-            $this->event->getCategoryIdsForWiki($wiki)
+            $this->event->getCategoryTitlesForWiki($wiki)
         );
         // Report the counts, and record them both for this wiki and the event (there's only ever one Wikidata wiki).
         $this->log(">> <info>Items created: {$ret['created']}</info>");


### PR DESCRIPTION
The new queries should go significantly faster than the older ones.
The drawback is we have to use category titles, not IDs. This may mean
we run into problems when querying for a large number of categories,
such as recursive categories.