### PR TITLE
Fix accepted types for query timeout, with -1 as no timeout

### DIFF
--- a/src/AppBundle/Model/Event.php
+++ b/src/AppBundle/Model/Event.php
@@ -14,7 +14,6 @@ use DateTimeZone;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**

--- a/src/AppBundle/Model/Program.php
+++ b/src/AppBundle/Model/Program.php
@@ -11,7 +11,6 @@ use AppBundle\Model\Traits\TitleUserTrait;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -436,7 +436,7 @@ class EventRepository extends Repository
             ->from('job')
             ->where("job_event_id = $eventId");
 
-        $ret = $this->executeQueryBuilder($rqb, false)->fetch();
+        $ret = $this->executeQueryBuilder($rqb, -1)->fetch();
         return isset($ret['job_started']) ? (bool)$ret['job_started'] : null;
     }
 }

--- a/src/AppBundle/Repository/Repository.php
+++ b/src/AppBundle/Repository/Repository.php
@@ -329,7 +329,7 @@ abstract class Repository extends EntityRepository
             ->setParameter('userIds', $userIds, Connection::PARAM_INT_ARRAY);
         // false means do not set a max query time. Here it's really fast,
         // and setting the query timeout actually slows it down.
-        return $this->executeQueryBuilder($rqb, false)->fetchAll();
+        return $this->executeQueryBuilder($rqb, -1)->fetchAll();
     }
 
     /**
@@ -374,13 +374,13 @@ abstract class Repository extends EntityRepository
      * Execute a query using the projects connection, handling certain Exceptions.
      * @param string $sql
      * @param mixed[] $params Parameters to bound to the prepared query.
-     * @param int|null|false $timeout Maximum statement time in seconds. null will use the
-     *   default specified by the app.query_timeout config parameter. false will set no timeout.
+     * @param int|null $timeout Maximum statement time in seconds. null will use the
+     *   default specified by the app.query_timeout config parameter. -1 will set no timeout.
      * @return ResultStatement
      * @throws DriverException
      * @throws DBALException
      */
-    public function executeReplicaQuery(string $sql, array $params = [], $timeout = null): ResultStatement
+    public function executeReplicaQuery(string $sql, array $params = [], ?int $timeout = null): ResultStatement
     {
         try {
             $sql = $this->getQueryTimeoutClause($timeout).$sql;
@@ -393,13 +393,13 @@ abstract class Repository extends EntityRepository
     /**
      * Execute a query using the projects connection, handling certain Exceptions.
      * @param QueryBuilder $qb
-     * @param int|null|false $timeout Maximum statement time in seconds. null will use the
-     *   default specified by the app.query_timeout config parameter. false will set no timeout.
+     * @param int|null $timeout Maximum statement time in seconds. null will use the
+     *   default specified by the app.query_timeout config parameter. -1 will set no timeout.
      * @return ResultStatement
      * @throws DriverException
      * @throws DBALException
      */
-    public function executeQueryBuilder(QueryBuilder $qb, $timeout = null): ResultStatement
+    public function executeQueryBuilder(QueryBuilder $qb, ?int $timeout = null): ResultStatement
     {
         try {
             $sql = $this->getQueryTimeoutClause($timeout).$qb->getSQL();
@@ -435,13 +435,13 @@ abstract class Repository extends EntityRepository
 
     /**
      * Set the maximum statement time on the MySQL engine.
-     * @param int|null|false $timeout In seconds. null will use the default specified by
-     *     the app.query_timeout config parameter. false will not set a timeout.
+     * @param int|null $timeout In seconds. null will use the default specified by
+     *     the app.query_timeout config parameter. -1 will not set a timeout.
      * @return string The SQL fragment to prepended to the query.
      */
-    public function getQueryTimeoutClause($timeout = null): string
+    public function getQueryTimeoutClause(?int $timeout = null): string
     {
-        if (false === $timeout) {
+        if (-1 === $timeout) {
             return '';
         }
 


### PR DESCRIPTION
Remove unused 'use' statements

Bug: https://phabricator.wikimedia.org/T208998